### PR TITLE
Add required Waylines template fields and overrides

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,557 @@
+const creationForm = document.getElementById('creationForm');
+const missionForm = document.getElementById('missionForm');
+const templateForm = document.getElementById('templateForm');
+const waypointForm = document.getElementById('waypointForm');
+const waypointTable = document.getElementById('waypointTable');
+const creationNowBtn = document.getElementById('creationNow');
+const waypointResetBtn = document.getElementById('waypointReset');
+const downloadKMLBtn = document.getElementById('downloadKML');
+const downloadKMZBtn = document.getElementById('downloadKMZ');
+const creationStatus = document.getElementById('creationStatus');
+const missionStatus = document.getElementById('missionStatus');
+const templateStatus = document.getElementById('templateStatus');
+
+const state = {
+  creation: {
+    author: '',
+    createTime: '',
+    updateTime: '',
+  },
+  mission: {
+    flyToWaylineMode: 'safely',
+    finishAction: 'goHome',
+    exitOnRCLost: 'goContinue',
+    executeRCLostAction: 'hover',
+    takeOffSecurityHeight: '',
+    takeOffRefPoint: '',
+    takeOffRefPointAGLHeight: '',
+    globalTransitionalSpeed: '',
+    globalRTHHeight: '',
+    droneEnumValue: '',
+    droneSubEnumValue: '',
+    payloadEnumValue: '',
+    payloadPositionIndex: '',
+  },
+  template: {
+    templateType: 'waypoint',
+    templateId: '',
+    coordinateMode: 'WGS84',
+    heightMode: 'EGM96',
+    globalShootHeight: '',
+    globalHeight: '',
+    positioningType: 'GPS',
+    surfaceFollowModeEnable: false,
+    surfaceRelativeHeight: '',
+    autoFlightSpeed: '',
+    gimbalPitchMode: 'usePointSetting',
+    waypointHeadingMode: 'followWayline',
+    waypointHeadingAngle: '',
+    waypointPoiPoint: '',
+    waypointHeadingPathMode: 'clockwise',
+    globalWaypointTurnMode: 'coordinateTurn',
+    globalUseStraightLine: false,
+    payloadParam: {
+      payloadPositionIndex: '',
+      focusMode: '',
+      meteringMode: '',
+      dewarpingEnable: '',
+      returnMode: '',
+      samplingRate: '',
+      scanningMode: '',
+      modelColoringEnable: '',
+      imageFormat: '',
+    },
+  },
+  waypoints: [],
+};
+
+let map;
+let markersLayer;
+
+initForms();
+initMap();
+renderWaypoints();
+updateDownloadState();
+
+function initForms() {
+  setFormValues(creationForm, state.creation);
+  setFormValues(missionForm, state.mission);
+  setFormValues(templateForm, state.template);
+
+  creationForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const data = new FormData(creationForm);
+    state.creation.author = data.get('author').trim();
+    state.creation.createTime = parseOptionalInteger(data.get('createTime'));
+    state.creation.updateTime = parseOptionalInteger(data.get('updateTime'));
+    updateStatus(creationStatus, '创建信息已保存');
+  });
+
+  missionForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const data = new FormData(missionForm);
+    state.mission.flyToWaylineMode = data.get('flyToWaylineMode');
+    state.mission.finishAction = data.get('finishAction');
+    state.mission.exitOnRCLost = data.get('exitOnRCLost');
+    state.mission.executeRCLostAction = data.get('executeRCLostAction');
+    state.mission.takeOffSecurityHeight = parseOptionalNumber(data.get('takeOffSecurityHeight'));
+    state.mission.takeOffRefPoint = data.get('takeOffRefPoint').trim();
+    state.mission.takeOffRefPointAGLHeight = parseOptionalNumber(data.get('takeOffRefPointAGLHeight'));
+    state.mission.globalTransitionalSpeed = parseOptionalNumber(data.get('globalTransitionalSpeed'));
+    state.mission.globalRTHHeight = parseOptionalNumber(data.get('globalRTHHeight'));
+    state.mission.droneEnumValue = parseOptionalInteger(data.get('droneEnumValue'));
+    state.mission.droneSubEnumValue = parseOptionalInteger(data.get('droneSubEnumValue'));
+    state.mission.payloadEnumValue = parseOptionalInteger(data.get('payloadEnumValue'));
+    state.mission.payloadPositionIndex = parseOptionalInteger(data.get('payloadPositionIndex'));
+    updateStatus(missionStatus, '任务信息已保存');
+  });
+
+  templateForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const data = new FormData(templateForm);
+    state.template.templateType = data.get('templateType');
+    state.template.templateId = parseOptionalInteger(data.get('templateId'));
+    state.template.coordinateMode = data.get('coordinateMode');
+    state.template.heightMode = data.get('heightMode');
+    state.template.globalShootHeight = parseOptionalNumber(data.get('globalShootHeight'));
+    state.template.globalHeight = parseOptionalNumber(data.get('globalHeight'));
+    state.template.positioningType = data.get('positioningType');
+    state.template.surfaceFollowModeEnable = data.get('surfaceFollowModeEnable') === 'on';
+    state.template.surfaceRelativeHeight = parseOptionalNumber(data.get('surfaceRelativeHeight'));
+    state.template.autoFlightSpeed = parseOptionalNumber(data.get('autoFlightSpeed'));
+    state.template.gimbalPitchMode = data.get('gimbalPitchMode');
+    state.template.waypointHeadingMode = data.get('waypointHeadingMode');
+    state.template.waypointHeadingAngle = parseOptionalNumber(data.get('waypointHeadingAngle'));
+    state.template.waypointPoiPoint = data.get('waypointPoiPoint').trim();
+    state.template.waypointHeadingPathMode = data.get('waypointHeadingPathMode');
+    state.template.globalWaypointTurnMode = data.get('globalWaypointTurnMode');
+    state.template.globalUseStraightLine = data.get('globalUseStraightLine') === 'on';
+    state.template.payloadParam.payloadPositionIndex = parseOptionalInteger(
+      data.get('payloadParam.payloadPositionIndex'),
+    );
+    state.template.payloadParam.focusMode = data.get('payloadParam.focusMode') || '';
+    state.template.payloadParam.meteringMode = data.get('payloadParam.meteringMode') || '';
+    state.template.payloadParam.dewarpingEnable = data.get('payloadParam.dewarpingEnable') || '';
+    state.template.payloadParam.returnMode = data.get('payloadParam.returnMode') || '';
+    state.template.payloadParam.samplingRate = parseOptionalInteger(data.get('payloadParam.samplingRate'));
+    state.template.payloadParam.scanningMode = data.get('payloadParam.scanningMode') || '';
+    state.template.payloadParam.modelColoringEnable = data.get('payloadParam.modelColoringEnable') || '';
+    state.template.payloadParam.imageFormat = (data.get('payloadParam.imageFormat') || '').trim();
+    updateStatus(templateStatus, '模板信息已保存');
+  });
+
+  waypointForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(waypointForm);
+    const editIndexValue = formData.get('editIndex');
+    const longitude = parseFloat(formData.get('longitude'));
+    const latitude = parseFloat(formData.get('latitude'));
+
+    if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) {
+      alert('请输入有效的经纬度');
+      return;
+    }
+
+    const waypoint = {
+      name: formData.get('name').trim() || '未命名航点',
+      description: formData.get('description').trim(),
+      longitude,
+      latitude,
+      coordinateAltitude: parseOptionalNumber(formData.get('coordinateAltitude')),
+      ellipsoidHeight: parseOptionalNumber(formData.get('ellipsoidHeight')),
+      height: parseOptionalNumber(formData.get('height')),
+      gimbalPitchAngle: parseOptionalNumber(formData.get('gimbalPitchAngle')),
+      useGlobalHeight: formData.get('useGlobalHeight') === 'on',
+      useGlobalSpeed: formData.get('useGlobalSpeed') === 'on',
+      useGlobalHeadingParam: formData.get('useGlobalHeadingParam') === 'on',
+      useGlobalTurnParam: formData.get('useGlobalTurnParam') === 'on',
+      waypointSpeed: parseOptionalNumber(formData.get('waypointSpeed')),
+      waypointHeadingMode: formData.get('waypointHeadingMode'),
+      waypointHeadingAngle: parseOptionalNumber(formData.get('waypointHeadingAngle')),
+      waypointPoiPoint: (formData.get('waypointPoiPoint') || '').trim(),
+      waypointHeadingPathMode: formData.get('waypointHeadingPathMode'),
+      waypointTurnMode: formData.get('waypointTurnMode'),
+      waypointTurnDampingDist: parseOptionalNumber(formData.get('waypointTurnDampingDist')),
+      useStraightLine: formData.get('useStraightLine') === 'on',
+      isRisky: formData.get('isRisky') === 'on',
+    };
+
+    const isEditing = editIndexValue !== null && editIndexValue !== '';
+    if (isEditing) {
+      state.waypoints[Number(editIndexValue)] = waypoint;
+    } else {
+      state.waypoints.push(waypoint);
+    }
+
+    renderWaypoints();
+    renderMarkers();
+    updateDownloadState();
+    resetWaypointForm();
+  });
+
+  waypointResetBtn.addEventListener('click', () => {
+    resetWaypointForm();
+    waypointForm.querySelector('input[name="name"]').focus();
+  });
+
+  ['useGlobalHeight', 'useGlobalSpeed', 'useGlobalHeadingParam', 'useGlobalTurnParam'].forEach((name) => {
+    const checkbox = waypointForm.elements[name];
+    if (checkbox) {
+      checkbox.addEventListener('change', updateWaypointFieldAvailability);
+    }
+  });
+
+  creationNowBtn.addEventListener('click', () => {
+    const now = Date.now();
+    creationForm.querySelector('input[name="createTime"]').value = now;
+    creationForm.querySelector('input[name="updateTime"]').value = now;
+  });
+
+  updateWaypointFieldAvailability();
+}
+
+function initMap() {
+  map = L.map('map', {
+    zoomControl: true,
+  }).setView([39.9042, 116.4074], 4);
+
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 18,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> 贡献者',
+  }).addTo(map);
+
+  markersLayer = L.layerGroup().addTo(map);
+}
+
+function renderWaypoints() {
+  if (state.waypoints.length === 0) {
+    waypointTable.innerHTML = '<tr class="empty-row"><td colspan="8">暂无航点，请使用上方表单逐项添加。</td></tr>';
+    return;
+  }
+
+  waypointTable.innerHTML = state.waypoints
+    .map((waypoint, index) => {
+      const inheritFlags = [
+        waypoint.useGlobalHeight ? '高' : '',
+        waypoint.useGlobalSpeed ? '速' : '',
+        waypoint.useGlobalHeadingParam ? '偏' : '',
+        waypoint.useGlobalTurnParam ? '转' : '',
+      ]
+        .filter(Boolean)
+        .join('/');
+      const badges = [];
+      if (waypoint.useStraightLine) {
+        badges.push('直线');
+      }
+      if (waypoint.isRisky) {
+        badges.push('危险');
+      }
+
+      return `
+        <tr>
+          <td>${index + 1}</td>
+          <td>${escapeHTML(waypoint.name)}</td>
+          <td>${waypoint.longitude.toFixed(6)}</td>
+          <td>${waypoint.latitude.toFixed(6)}</td>
+          <td>${formatOptionalNumber(waypoint.height)}</td>
+          <td>${inheritFlags || '无'}</td>
+          <td>${badges.length ? badges.join('/') : '无'}</td>
+          <td>
+            <button type="button" class="secondary" data-action="edit" data-index="${index}">编辑</button>
+            <button type="button" data-action="delete" data-index="${index}">删除</button>
+          </td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  waypointTable.querySelectorAll('button').forEach((button) => {
+    button.addEventListener('click', () => handleWaypointRowAction(button.dataset));
+  });
+}
+
+function handleWaypointRowAction({ action, index }) {
+  const waypoint = state.waypoints[Number(index)];
+  if (!waypoint) return;
+
+  if (action === 'edit') {
+    setFormValues(waypointForm, {
+      editIndex: index,
+      ...waypoint,
+    });
+    updateWaypointFieldAvailability();
+  }
+
+  if (action === 'delete') {
+    if (confirm(`确定删除航点“${waypoint.name}”吗？`)) {
+      state.waypoints.splice(Number(index), 1);
+      renderWaypoints();
+      renderMarkers();
+      updateDownloadState();
+      resetWaypointForm();
+    }
+  }
+}
+
+function renderMarkers() {
+  markersLayer.clearLayers();
+  if (state.waypoints.length === 0) return;
+
+  const bounds = [];
+  state.waypoints.forEach((waypoint) => {
+    const marker = L.marker([waypoint.latitude, waypoint.longitude]).bindPopup(
+      `<strong>${escapeHTML(waypoint.name)}</strong><br/>${escapeHTML(waypoint.description || '无描述')}`,
+    );
+    marker.addTo(markersLayer);
+    bounds.push([waypoint.latitude, waypoint.longitude]);
+  });
+
+  if (bounds.length === 1) {
+    map.setView(bounds[0], 12);
+  } else {
+    map.fitBounds(bounds, { padding: [24, 24] });
+  }
+}
+
+function resetWaypointForm() {
+  waypointForm.reset();
+  waypointForm.querySelector('input[name="editIndex"]').value = '';
+  ['useGlobalHeight', 'useGlobalSpeed', 'useGlobalHeadingParam', 'useGlobalTurnParam'].forEach((name) => {
+    const field = waypointForm.elements[name];
+    if (field) field.checked = true;
+  });
+  ['useStraightLine', 'isRisky'].forEach((name) => {
+    const field = waypointForm.elements[name];
+    if (field) field.checked = false;
+  });
+  updateWaypointFieldAvailability();
+}
+
+function updateDownloadState() {
+  const disabled = state.waypoints.length === 0;
+  downloadKMLBtn.disabled = disabled;
+  downloadKMZBtn.disabled = disabled;
+  downloadKMLBtn.classList.toggle('disabled', disabled);
+  downloadKMZBtn.classList.toggle('disabled', disabled);
+}
+
+downloadKMLBtn.addEventListener('click', () => {
+  const kml = generateKML();
+  const blob = new Blob([kml], { type: 'application/vnd.google-earth.kml+xml' });
+  triggerDownload('template.kml', blob);
+});
+
+downloadKMZBtn.addEventListener('click', async () => {
+  const zip = new JSZip();
+  zip.file('doc.kml', generateKML());
+  const blob = await zip.generateAsync({ type: 'blob' });
+  triggerDownload('template.kmz', blob);
+});
+
+function generateKML() {
+  const creationXML = [
+    optionalTag('wpml:author', state.creation.author),
+    optionalTag('wpml:createTime', state.creation.createTime),
+    optionalTag('wpml:updateTime', state.creation.updateTime),
+  ]
+    .filter(Boolean)
+    .join('\n      ');
+
+  const missionXML = [
+    `<wpml:flyToWaylineMode>${state.mission.flyToWaylineMode}</wpml:flyToWaylineMode>`,
+    `<wpml:finishAction>${state.mission.finishAction}</wpml:finishAction>`,
+    `<wpml:exitOnRCLost>${state.mission.exitOnRCLost}</wpml:exitOnRCLost>`,
+    `<wpml:executeRCLostAction>${state.mission.executeRCLostAction}</wpml:executeRCLostAction>`,
+    optionalTag('wpml:takeOffSecurityHeight', state.mission.takeOffSecurityHeight),
+    optionalTag('wpml:takeOffRefPoint', state.mission.takeOffRefPoint),
+    optionalTag('wpml:takeOffRefPointAGLHeight', state.mission.takeOffRefPointAGLHeight),
+    optionalTag('wpml:globalTransitionalSpeed', state.mission.globalTransitionalSpeed),
+    optionalTag('wpml:globalRTHHeight', state.mission.globalRTHHeight),
+    state.mission.droneEnumValue !== ''
+      ? `<wpml:droneInfo>\n        <wpml:droneEnumValue>${state.mission.droneEnumValue}</wpml:droneEnumValue>\n        ${optionalTag(
+            'wpml:droneSubEnumValue',
+            state.mission.droneSubEnumValue,
+            '        ',
+          )}\n      </wpml:droneInfo>`
+      : '',
+    state.mission.payloadEnumValue !== ''
+      ? `<wpml:payloadInfo>\n        <wpml:payloadEnumValue>${state.mission.payloadEnumValue}</wpml:payloadEnumValue>\n        ${optionalTag(
+            'wpml:payloadPositionIndex',
+            state.mission.payloadPositionIndex,
+            '        ',
+          )}\n      </wpml:payloadInfo>`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n      ');
+
+  const payloadParam = state.template.payloadParam;
+  const payloadParamInner = [
+    optionalTag('wpml:payloadPositionIndex', payloadParam.payloadPositionIndex, '        '),
+    optionalTag('wpml:focusMode', payloadParam.focusMode, '        '),
+    optionalTag('wpml:meteringMode', payloadParam.meteringMode, '        '),
+    optionalTag('wpml:dewarpingEnable', payloadParam.dewarpingEnable, '        '),
+    optionalTag('wpml:returnMode', payloadParam.returnMode, '        '),
+    optionalTag('wpml:samplingRate', payloadParam.samplingRate, '        '),
+    optionalTag('wpml:scanningMode', payloadParam.scanningMode, '        '),
+    optionalTag('wpml:modelColoringEnable', payloadParam.modelColoringEnable, '        '),
+    optionalTag('wpml:imageFormat', payloadParam.imageFormat, '        '),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const payloadParamXML = payloadParamInner
+    ? `<wpml:payloadParam>\n${payloadParamInner}\n      </wpml:payloadParam>`
+    : '';
+
+  const folderXML = [
+    `<wpml:templateType>${state.template.templateType}</wpml:templateType>`,
+    optionalTag('wpml:templateId', state.template.templateId),
+    `<wpml:waylineCoordinateSysParam>\n        <wpml:coordinateMode>${state.template.coordinateMode}</wpml:coordinateMode>\n        <wpml:heightMode>${state.template.heightMode}</wpml:heightMode>\n        ${optionalTag('wpml:globalShootHeight', state.template.globalShootHeight, '        ')}\n        <wpml:positioningType>${state.template.positioningType}</wpml:positioningType>\n        <wpml:surfaceFollowModeEnable>${state.template.surfaceFollowModeEnable ? 1 : 0}</wpml:surfaceFollowModeEnable>\n        ${optionalTag('wpml:surfaceRelativeHeight', state.template.surfaceRelativeHeight, '        ')}\n      </wpml:waylineCoordinateSysParam>`,
+    optionalTag('wpml:autoFlightSpeed', state.template.autoFlightSpeed),
+    optionalTag('wpml:globalHeight', state.template.globalHeight),
+    `<wpml:gimbalPitchMode>${state.template.gimbalPitchMode}</wpml:gimbalPitchMode>`,
+    `<wpml:globalWaypointHeadingParam>\n        <wpml:waypointHeadingMode>${state.template.waypointHeadingMode}</wpml:waypointHeadingMode>\n        ${optionalTag('wpml:waypointHeadingAngle', state.template.waypointHeadingAngle, '        ')}\n        ${optionalTag('wpml:waypointPoiPoint', state.template.waypointPoiPoint, '        ')}\n        <wpml:waypointHeadingPathMode>${state.template.waypointHeadingPathMode}</wpml:waypointHeadingPathMode>\n      </wpml:globalWaypointHeadingParam>`,
+    `<wpml:globalWaypointTurnMode>${state.template.globalWaypointTurnMode}</wpml:globalWaypointTurnMode>`,
+    `<wpml:globalUseStraightLine>${state.template.globalUseStraightLine ? 1 : 0}</wpml:globalUseStraightLine>`,
+    payloadParamXML,
+    state.waypoints
+      .map((waypoint, index) => {
+        const coordinates = [waypoint.longitude, waypoint.latitude];
+        if (Number.isFinite(waypoint.coordinateAltitude)) {
+          coordinates.push(waypoint.coordinateAltitude);
+        }
+        const waypointSpeedXML = !waypoint.useGlobalSpeed
+          ? optionalTag('wpml:waypointSpeed', waypoint.waypointSpeed, '        ')
+          : '';
+        const waypointHeadingParamXML = !waypoint.useGlobalHeadingParam
+          ? `        <wpml:waypointHeadingParam>\n          <wpml:waypointHeadingMode>${waypoint.waypointHeadingMode}</wpml:waypointHeadingMode>\n          ${optionalTag('wpml:waypointHeadingAngle', waypoint.waypointHeadingAngle, '          ')}\n          ${optionalTag('wpml:waypointPoiPoint', waypoint.waypointPoiPoint, '          ')}\n          <wpml:waypointHeadingPathMode>${waypoint.waypointHeadingPathMode}</wpml:waypointHeadingPathMode>\n        </wpml:waypointHeadingParam>`
+          : '';
+        const waypointTurnParamXML = !waypoint.useGlobalTurnParam
+          ? `        <wpml:waypointTurnParam>\n          <wpml:waypointTurnMode>${waypoint.waypointTurnMode}</wpml:waypointTurnMode>\n          ${optionalTag('wpml:waypointTurnDampingDist', waypoint.waypointTurnDampingDist, '          ')}\n        </wpml:waypointTurnParam>`
+          : '';
+        return `      <Placemark>\n        <name>${escapeXML(waypoint.name)}</name>\n        ${optionalTag('description', waypoint.description, '        ')}\n        <Point>\n          <coordinates>${coordinates.join(',')}</coordinates>\n        </Point>\n        <wpml:index>${index}</wpml:index>\n        ${optionalTag('wpml:ellipsoidHeight', waypoint.ellipsoidHeight, '        ')}\n        ${optionalTag('wpml:height', waypoint.height, '        ')}\n        <wpml:useGlobalHeight>${waypoint.useGlobalHeight ? 1 : 0}</wpml:useGlobalHeight>\n        <wpml:useGlobalSpeed>${waypoint.useGlobalSpeed ? 1 : 0}</wpml:useGlobalSpeed>\n        <wpml:useGlobalHeadingParam>${waypoint.useGlobalHeadingParam ? 1 : 0}</wpml:useGlobalHeadingParam>\n        <wpml:useGlobalTurnParam>${waypoint.useGlobalTurnParam ? 1 : 0}</wpml:useGlobalTurnParam>\n        ${waypointSpeedXML}\n        ${waypointHeadingParamXML}\n        ${waypointTurnParamXML}\n        <wpml:useStraightLine>${waypoint.useStraightLine ? 1 : 0}</wpml:useStraightLine>\n        <wpml:isRisky>${waypoint.isRisky ? 1 : 0}</wpml:isRisky>\n        ${optionalTag('wpml:gimbalPitchAngle', waypoint.gimbalPitchAngle, '        ')}\n      </Placemark>`;
+      })
+      .join('\n'),
+  ]
+    .filter(Boolean)
+    .join('\n      ');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:wpml="http://www.dji.com/wpmz/1.0.2">
+  <Document>
+    ${creationXML}
+    <wpml:missionConfig>
+      ${missionXML}
+    </wpml:missionConfig>
+    <Folder>
+      ${folderXML}
+    </Folder>
+  </Document>
+</kml>`;
+}
+
+function optionalTag(tagName, value, indent = '      ') {
+  if (value === null || value === undefined || value === '') {
+    return '';
+  }
+  return `${indent}<${tagName}>${escapeXML(value)}</${tagName}>`;
+}
+
+function triggerDownload(filename, blob) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function setFormValues(form, values) {
+  setFormValuesWithPrefix(form, values, '');
+}
+
+function setFormValuesWithPrefix(form, values, prefix) {
+  Object.entries(values).forEach(([name, value]) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      setFormValuesWithPrefix(form, value, `${prefix}${name}.`);
+      return;
+    }
+
+    const field = form.querySelector(`[name="${prefix}${name}"]`);
+    if (!field) return;
+
+    if (field.type === 'checkbox') {
+      field.checked = Boolean(value);
+    } else {
+      field.value = value ?? '';
+    }
+  });
+}
+
+function parseOptionalNumber(value) {
+  const text = `${value ?? ''}`.trim();
+  if (text === '') return '';
+  const number = Number.parseFloat(text);
+  return Number.isFinite(number) ? number : '';
+}
+
+function parseOptionalInteger(value) {
+  const text = `${value ?? ''}`.trim();
+  if (text === '') return '';
+  const number = Number.parseInt(text, 10);
+  return Number.isInteger(number) ? number : '';
+}
+
+function updateStatus(element, message) {
+  const time = new Date().toLocaleTimeString();
+  element.textContent = `${message}（${time}）`;
+}
+
+function escapeHTML(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeXML(value) {
+  return escapeHTML(value);
+}
+
+function formatOptionalNumber(value) {
+  return value === '' || value === null || value === undefined ? '-' : Number(value).toFixed(2);
+}
+
+function updateWaypointFieldAvailability() {
+  const useGlobalHeight = waypointForm.elements.useGlobalHeight?.checked;
+  toggleFieldAvailability(waypointForm.elements.ellipsoidHeight, Boolean(useGlobalHeight));
+  toggleFieldAvailability(waypointForm.elements.height, Boolean(useGlobalHeight));
+
+  const useGlobalSpeed = waypointForm.elements.useGlobalSpeed?.checked;
+  toggleFieldAvailability(waypointForm.elements.waypointSpeed, Boolean(useGlobalSpeed));
+
+  const useGlobalHeadingParam = waypointForm.elements.useGlobalHeadingParam?.checked;
+  ['waypointHeadingMode', 'waypointHeadingAngle', 'waypointPoiPoint', 'waypointHeadingPathMode'].forEach((name) => {
+    toggleFieldAvailability(waypointForm.elements[name], Boolean(useGlobalHeadingParam));
+  });
+
+  const useGlobalTurnParam = waypointForm.elements.useGlobalTurnParam?.checked;
+  ['waypointTurnMode', 'waypointTurnDampingDist'].forEach((name) => {
+    toggleFieldAvailability(waypointForm.elements[name], Boolean(useGlobalTurnParam));
+  });
+  toggleFieldAvailability(waypointForm.elements.useStraightLine, Boolean(useGlobalTurnParam));
+}
+
+function toggleFieldAvailability(field, disabled) {
+  if (!field) return;
+  field.disabled = disabled;
+  const label = field.closest('label');
+  if (label) {
+    label.classList.toggle('field-disabled', disabled);
+  }
+}

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const missionForm = document.getElementById('missionForm');
 const templateForm = document.getElementById('templateForm');
 const waypointForm = document.getElementById('waypointForm');
 const waypointTable = document.getElementById('waypointTable');
+const kmzInput = document.getElementById('kmzInput');
 const creationNowBtn = document.getElementById('creationNow');
 const waypointResetBtn = document.getElementById('waypointReset');
 const downloadKMLBtn = document.getElementById('downloadKML');
@@ -15,6 +16,18 @@ const waylinesPreview = document.getElementById('waylinesPreview');
 
 const TEMPLATE_PREVIEW_PLACEHOLDER = '请填写表单以生成 template.kml 预览。';
 const WAYLINES_PREVIEW_PLACEHOLDER = '请填写表单并添加航点以生成 waylines.wpml 预览。';
+
+const PAYLOAD_PARAM_DEFAULTS = {
+  payloadPositionIndex: '',
+  focusMode: '',
+  meteringMode: '',
+  dewarpingEnable: '',
+  returnMode: '',
+  samplingRate: '',
+  scanningMode: '',
+  modelColoringEnable: '',
+  imageFormat: '',
+};
 
 const state = {
   creation: {
@@ -55,17 +68,7 @@ const state = {
     waypointHeadingPathMode: 'clockwise',
     globalWaypointTurnMode: 'coordinateTurn',
     globalUseStraightLine: false,
-    payloadParam: {
-      payloadPositionIndex: '',
-      focusMode: '',
-      meteringMode: '',
-      dewarpingEnable: '',
-      returnMode: '',
-      samplingRate: '',
-      scanningMode: '',
-      modelColoringEnable: '',
-      imageFormat: '',
-    },
+    payloadParam: { ...PAYLOAD_PARAM_DEFAULTS },
   },
   waypoints: [],
 };
@@ -75,6 +78,7 @@ let markersLayer;
 
 initForms();
 initMap();
+initImportControls();
 renderWaypoints();
 updateDownloadState();
 
@@ -229,6 +233,307 @@ function initMap() {
   }).addTo(map);
 
   markersLayer = L.layerGroup().addTo(map);
+}
+
+function initImportControls() {
+  if (!kmzInput) return;
+  kmzInput.addEventListener('change', handleKMZSelection);
+}
+
+async function handleKMZSelection(event) {
+  const file = event.target.files?.[0];
+  if (!file) return;
+
+  try {
+    if (file.name.toLowerCase().endsWith('.kml')) {
+      const text = await file.text();
+      loadTemplateFromText(text, file.name);
+    } else {
+      await loadKMZFile(file);
+    }
+  } catch (error) {
+    console.error('导入 KMZ/KML 失败', error);
+    alert(`导入失败：${error.message || error}`);
+  } finally {
+    event.target.value = '';
+  }
+}
+
+async function loadKMZFile(file) {
+  const arrayBuffer = await file.arrayBuffer();
+  const zip = await JSZip.loadAsync(arrayBuffer);
+  const templateFile = zip.file(/template\.kml$/i)[0] || zip.file(/\.kml$/i)[0];
+  if (!templateFile) {
+    throw new Error('KMZ 中未找到 template.kml');
+  }
+  const templateText = await templateFile.async('string');
+  loadTemplateFromText(templateText, file.name);
+}
+
+function loadTemplateFromText(kmlText, sourceName = '文件') {
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(kmlText, 'application/xml');
+  if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
+    throw new Error('无法解析提供的 KML/XML 内容');
+  }
+
+  const documentNode = xmlDoc.getElementsByTagName('Document')[0];
+  if (!documentNode) {
+    throw new Error('template.kml 中缺少 Document 节点');
+  }
+
+  const missionNode = documentNode.getElementsByTagName('wpml:missionConfig')[0];
+  const folderNode = documentNode.getElementsByTagName('Folder')[0];
+
+  if (!folderNode) {
+    throw new Error('template.kml 中缺少 Folder 节点');
+  }
+
+  const creation = parseCreation(documentNode);
+  const mission = missionNode ? parseMission(missionNode) : { ...state.mission };
+  const templateData = parseTemplate(folderNode);
+  const waypoints = parseWaypoints(folderNode, templateData);
+
+  applyImportedState({ creation, mission, template: templateData, waypoints }, sourceName);
+}
+
+function applyImportedState(imported, sourceName) {
+  if (imported.creation) {
+    Object.assign(state.creation, imported.creation);
+  }
+
+  if (imported.mission) {
+    Object.assign(state.mission, imported.mission);
+  }
+
+  if (imported.template) {
+    Object.assign(state.template, imported.template);
+    state.template.payloadParam = {
+      ...PAYLOAD_PARAM_DEFAULTS,
+      ...(imported.template.payloadParam || {}),
+    };
+  }
+
+  state.waypoints = Array.isArray(imported.waypoints) ? imported.waypoints : [];
+
+  setFormValues(creationForm, state.creation);
+  setFormValues(missionForm, state.mission);
+  setFormValues(templateForm, state.template);
+
+  renderWaypoints();
+  renderMarkers();
+  updateDownloadState();
+  resetWaypointForm();
+  updateWaypointFieldAvailability();
+
+  const suffix = sourceName ? `已从 ${sourceName} 导入` : '已导入';
+  updateStatus(creationStatus, `创建信息${suffix}`);
+  updateStatus(missionStatus, `任务配置${suffix}`);
+  updateStatus(templateStatus, `模板参数${suffix}`);
+}
+
+function parseCreation(documentNode) {
+  return {
+    author: getTextContent(documentNode, 'wpml:author'),
+    createTime: parseOptionalInteger(getTextContent(documentNode, 'wpml:createTime')),
+    updateTime: parseOptionalInteger(getTextContent(documentNode, 'wpml:updateTime')),
+  };
+}
+
+function parseMission(missionNode) {
+  const mission = {
+    flyToWaylineMode: getTextOrDefault(missionNode, 'wpml:flyToWaylineMode', state.mission.flyToWaylineMode),
+    finishAction: getTextOrDefault(missionNode, 'wpml:finishAction', state.mission.finishAction),
+    exitOnRCLost: getTextOrDefault(missionNode, 'wpml:exitOnRCLost', state.mission.exitOnRCLost),
+    executeRCLostAction: getTextOrDefault(
+      missionNode,
+      'wpml:executeRCLostAction',
+      state.mission.executeRCLostAction,
+    ),
+    takeOffSecurityHeight: parseOptionalNumber(getTextContent(missionNode, 'wpml:takeOffSecurityHeight')),
+    takeOffRefPoint: getTextContent(missionNode, 'wpml:takeOffRefPoint'),
+    takeOffRefPointAGLHeight: parseOptionalNumber(
+      getTextContent(missionNode, 'wpml:takeOffRefPointAGLHeight'),
+    ),
+    globalTransitionalSpeed: parseOptionalNumber(getTextContent(missionNode, 'wpml:globalTransitionalSpeed')),
+    globalRTHHeight: parseOptionalNumber(getTextContent(missionNode, 'wpml:globalRTHHeight')),
+    droneEnumValue: '',
+    droneSubEnumValue: '',
+    payloadEnumValue: '',
+    payloadPositionIndex: '',
+  };
+
+  const droneInfo = missionNode.getElementsByTagName('wpml:droneInfo')[0];
+  if (droneInfo) {
+    mission.droneEnumValue = parseOptionalInteger(getTextContent(droneInfo, 'wpml:droneEnumValue'));
+    mission.droneSubEnumValue = parseOptionalInteger(getTextContent(droneInfo, 'wpml:droneSubEnumValue'));
+  }
+
+  const payloadInfo = missionNode.getElementsByTagName('wpml:payloadInfo')[0];
+  if (payloadInfo) {
+    mission.payloadEnumValue = parseOptionalInteger(getTextContent(payloadInfo, 'wpml:payloadEnumValue'));
+    mission.payloadPositionIndex = parseOptionalInteger(
+      getTextContent(payloadInfo, 'wpml:payloadPositionIndex'),
+    );
+  }
+
+  return mission;
+}
+
+function parseTemplate(folderNode) {
+  const coordinateNode = folderNode.getElementsByTagName('wpml:waylineCoordinateSysParam')[0];
+  const headingNode = folderNode.getElementsByTagName('wpml:globalWaypointHeadingParam')[0];
+  const payloadNode = folderNode.getElementsByTagName('wpml:payloadParam')[0];
+
+  return {
+    templateType: getTextOrDefault(folderNode, 'wpml:templateType', state.template.templateType),
+    templateId: parseOptionalInteger(getTextContent(folderNode, 'wpml:templateId')),
+    coordinateMode: coordinateNode
+      ? getTextOrDefault(coordinateNode, 'wpml:coordinateMode', state.template.coordinateMode)
+      : state.template.coordinateMode,
+    heightMode: coordinateNode
+      ? getTextOrDefault(coordinateNode, 'wpml:heightMode', state.template.heightMode)
+      : state.template.heightMode,
+    globalShootHeight: coordinateNode
+      ? parseOptionalNumber(getTextContent(coordinateNode, 'wpml:globalShootHeight'))
+      : '',
+    globalHeight: parseOptionalNumber(getTextContent(folderNode, 'wpml:globalHeight')),
+    positioningType: coordinateNode
+      ? getTextOrDefault(coordinateNode, 'wpml:positioningType', state.template.positioningType)
+      : state.template.positioningType,
+    surfaceFollowModeEnable: coordinateNode
+      ? parseBooleanFlag(getTextContent(coordinateNode, 'wpml:surfaceFollowModeEnable'))
+      : false,
+    surfaceRelativeHeight: coordinateNode
+      ? parseOptionalNumber(getTextContent(coordinateNode, 'wpml:surfaceRelativeHeight'))
+      : '',
+    autoFlightSpeed: parseOptionalNumber(getTextContent(folderNode, 'wpml:autoFlightSpeed')),
+    gimbalPitchMode: getTextOrDefault(folderNode, 'wpml:gimbalPitchMode', state.template.gimbalPitchMode),
+    waypointHeadingMode: headingNode
+      ? getTextOrDefault(headingNode, 'wpml:waypointHeadingMode', state.template.waypointHeadingMode)
+      : state.template.waypointHeadingMode,
+    waypointHeadingAngle: headingNode
+      ? parseOptionalNumber(getTextContent(headingNode, 'wpml:waypointHeadingAngle'))
+      : '',
+    waypointPoiPoint: headingNode ? getTextContent(headingNode, 'wpml:waypointPoiPoint') : '',
+    waypointHeadingPathMode: headingNode
+      ? getTextOrDefault(headingNode, 'wpml:waypointHeadingPathMode', state.template.waypointHeadingPathMode)
+      : state.template.waypointHeadingPathMode,
+    globalWaypointTurnMode: getTextOrDefault(
+      folderNode,
+      'wpml:globalWaypointTurnMode',
+      state.template.globalWaypointTurnMode,
+    ),
+    globalUseStraightLine: parseBooleanFlag(
+      getTextContent(folderNode, 'wpml:globalUseStraightLine'),
+      state.template.globalUseStraightLine,
+    ),
+    payloadParam: parsePayloadParam(payloadNode),
+  };
+}
+
+function parsePayloadParam(payloadNode) {
+  if (!payloadNode) {
+    return { ...PAYLOAD_PARAM_DEFAULTS };
+  }
+
+  return {
+    ...PAYLOAD_PARAM_DEFAULTS,
+    payloadPositionIndex: parseOptionalInteger(getTextContent(payloadNode, 'wpml:payloadPositionIndex')),
+    focusMode: getTextContent(payloadNode, 'wpml:focusMode'),
+    meteringMode: getTextContent(payloadNode, 'wpml:meteringMode'),
+    dewarpingEnable: getTextContent(payloadNode, 'wpml:dewarpingEnable'),
+    returnMode: getTextContent(payloadNode, 'wpml:returnMode'),
+    samplingRate: parseOptionalInteger(getTextContent(payloadNode, 'wpml:samplingRate')),
+    scanningMode: getTextContent(payloadNode, 'wpml:scanningMode'),
+    modelColoringEnable: getTextContent(payloadNode, 'wpml:modelColoringEnable'),
+    imageFormat: getTextContent(payloadNode, 'wpml:imageFormat'),
+  };
+}
+
+function parseWaypoints(folderNode, templateDefaults) {
+  return Array.from(folderNode.getElementsByTagName('Placemark')).map((placemark) =>
+    parseWaypointPlacemark(placemark, templateDefaults),
+  );
+}
+
+function parseWaypointPlacemark(placemark, templateDefaults) {
+  const coordinateText = getTextContent(placemark, 'coordinates');
+  const coordinateParts = coordinateText
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part !== '');
+
+  const longitude = Number.parseFloat(coordinateParts[0]);
+  const latitude = Number.parseFloat(coordinateParts[1]);
+
+  if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) {
+    throw new Error('航点坐标缺失或无效，无法导入。');
+  }
+
+  const coordinateAltitude = coordinateParts[2] !== undefined ? parseOptionalNumber(coordinateParts[2]) : '';
+
+  const useGlobalHeight = parseBooleanFlag(getTextContent(placemark, 'wpml:useGlobalHeight'), true);
+  const useGlobalSpeed = parseBooleanFlag(getTextContent(placemark, 'wpml:useGlobalSpeed'), true);
+  const useGlobalHeadingParam = parseBooleanFlag(
+    getTextContent(placemark, 'wpml:useGlobalHeadingParam'),
+    true,
+  );
+  const useGlobalTurnParam = parseBooleanFlag(getTextContent(placemark, 'wpml:useGlobalTurnParam'), true);
+
+  const headingNode = placemark.getElementsByTagName('wpml:waypointHeadingParam')[0];
+  const turnNode = placemark.getElementsByTagName('wpml:waypointTurnParam')[0];
+
+  return {
+    name: getTextOrDefault(placemark, 'name', '未命名航点'),
+    description: getTextContent(placemark, 'description'),
+    longitude,
+    latitude,
+    coordinateAltitude,
+    ellipsoidHeight: parseOptionalNumber(getTextContent(placemark, 'wpml:ellipsoidHeight')),
+    height: parseOptionalNumber(getTextContent(placemark, 'wpml:height')),
+    gimbalPitchAngle: parseOptionalNumber(getTextContent(placemark, 'wpml:gimbalPitchAngle')),
+    useGlobalHeight,
+    useGlobalSpeed,
+    useGlobalHeadingParam,
+    useGlobalTurnParam,
+    waypointSpeed: useGlobalSpeed ? '' : parseOptionalNumber(getTextContent(placemark, 'wpml:waypointSpeed')),
+    waypointHeadingMode: headingNode
+      ? getTextOrDefault(headingNode, 'wpml:waypointHeadingMode', templateDefaults.waypointHeadingMode)
+      : templateDefaults.waypointHeadingMode,
+    waypointHeadingAngle: headingNode
+      ? parseOptionalNumber(getTextContent(headingNode, 'wpml:waypointHeadingAngle'))
+      : '',
+    waypointPoiPoint: headingNode ? getTextContent(headingNode, 'wpml:waypointPoiPoint') : '',
+    waypointHeadingPathMode: headingNode
+      ? getTextOrDefault(headingNode, 'wpml:waypointHeadingPathMode', templateDefaults.waypointHeadingPathMode)
+      : templateDefaults.waypointHeadingPathMode,
+    waypointTurnMode: turnNode
+      ? getTextOrDefault(turnNode, 'wpml:waypointTurnMode', templateDefaults.globalWaypointTurnMode)
+      : templateDefaults.globalWaypointTurnMode,
+    waypointTurnDampingDist: turnNode
+      ? parseOptionalNumber(getTextContent(turnNode, 'wpml:waypointTurnDampingDist'))
+      : '',
+    useStraightLine: parseBooleanFlag(getTextContent(placemark, 'wpml:useStraightLine'), false),
+    isRisky: parseBooleanFlag(getTextContent(placemark, 'wpml:isRisky'), false),
+  };
+}
+
+function getTextContent(parent, tagName) {
+  if (!parent) return '';
+  const element = parent.getElementsByTagName(tagName)[0];
+  return element ? element.textContent.trim() : '';
+}
+
+function getTextOrDefault(parent, tagName, fallback = '') {
+  const value = getTextContent(parent, tagName);
+  return value === '' ? fallback : value;
+}
+
+function parseBooleanFlag(value, defaultValue = false) {
+  const text = `${value ?? ''}`.trim();
+  if (text === '') return defaultValue;
+  return text === '1' || text.toLowerCase() === 'true';
 }
 
 function renderWaypoints() {

--- a/app.js
+++ b/app.js
@@ -10,6 +10,11 @@ const downloadKMZBtn = document.getElementById('downloadKMZ');
 const creationStatus = document.getElementById('creationStatus');
 const missionStatus = document.getElementById('missionStatus');
 const templateStatus = document.getElementById('templateStatus');
+const templatePreview = document.getElementById('templatePreview');
+const waylinesPreview = document.getElementById('waylinesPreview');
+
+const TEMPLATE_PREVIEW_PLACEHOLDER = '请填写表单以生成 template.kml 预览。';
+const WAYLINES_PREVIEW_PLACEHOLDER = '请填写表单并添加航点以生成 waylines.wpml 预览。';
 
 const state = {
   creation: {
@@ -85,6 +90,7 @@ function initForms() {
     state.creation.createTime = parseOptionalInteger(data.get('createTime'));
     state.creation.updateTime = parseOptionalInteger(data.get('updateTime'));
     updateStatus(creationStatus, '创建信息已保存');
+    updateXMLPreview();
   });
 
   missionForm.addEventListener('submit', (event) => {
@@ -104,6 +110,7 @@ function initForms() {
     state.mission.payloadEnumValue = parseOptionalInteger(data.get('payloadEnumValue'));
     state.mission.payloadPositionIndex = parseOptionalInteger(data.get('payloadPositionIndex'));
     updateStatus(missionStatus, '任务信息已保存');
+    updateXMLPreview();
   });
 
   templateForm.addEventListener('submit', (event) => {
@@ -138,6 +145,7 @@ function initForms() {
     state.template.payloadParam.modelColoringEnable = data.get('payloadParam.modelColoringEnable') || '';
     state.template.payloadParam.imageFormat = (data.get('payloadParam.imageFormat') || '').trim();
     updateStatus(templateStatus, '模板信息已保存');
+    updateXMLPreview();
   });
 
   waypointForm.addEventListener('submit', (event) => {
@@ -226,6 +234,7 @@ function initMap() {
 function renderWaypoints() {
   if (state.waypoints.length === 0) {
     waypointTable.innerHTML = '<tr class="empty-row"><td colspan="8">暂无航点，请使用上方表单逐项添加。</td></tr>';
+    updateXMLPreview();
     return;
   }
 
@@ -268,6 +277,8 @@ function renderWaypoints() {
   waypointTable.querySelectorAll('button').forEach((button) => {
     button.addEventListener('click', () => handleWaypointRowAction(button.dataset));
   });
+
+  updateXMLPreview();
 }
 
 function handleWaypointRowAction({ action, index }) {
@@ -343,7 +354,8 @@ downloadKMLBtn.addEventListener('click', () => {
 
 downloadKMZBtn.addEventListener('click', async () => {
   const zip = new JSZip();
-  zip.file('doc.kml', generateKML());
+  zip.file('template.kml', generateKML());
+  zip.file('waylines.wpml', generateWaylines());
   const blob = await zip.generateAsync({ type: 'blob' });
   triggerDownload('template.kmz', blob);
 });
@@ -357,52 +369,8 @@ function generateKML() {
     .filter(Boolean)
     .join('\n      ');
 
-  const missionXML = [
-    `<wpml:flyToWaylineMode>${state.mission.flyToWaylineMode}</wpml:flyToWaylineMode>`,
-    `<wpml:finishAction>${state.mission.finishAction}</wpml:finishAction>`,
-    `<wpml:exitOnRCLost>${state.mission.exitOnRCLost}</wpml:exitOnRCLost>`,
-    `<wpml:executeRCLostAction>${state.mission.executeRCLostAction}</wpml:executeRCLostAction>`,
-    optionalTag('wpml:takeOffSecurityHeight', state.mission.takeOffSecurityHeight),
-    optionalTag('wpml:takeOffRefPoint', state.mission.takeOffRefPoint),
-    optionalTag('wpml:takeOffRefPointAGLHeight', state.mission.takeOffRefPointAGLHeight),
-    optionalTag('wpml:globalTransitionalSpeed', state.mission.globalTransitionalSpeed),
-    optionalTag('wpml:globalRTHHeight', state.mission.globalRTHHeight),
-    state.mission.droneEnumValue !== ''
-      ? `<wpml:droneInfo>\n        <wpml:droneEnumValue>${state.mission.droneEnumValue}</wpml:droneEnumValue>\n        ${optionalTag(
-            'wpml:droneSubEnumValue',
-            state.mission.droneSubEnumValue,
-            '        ',
-          )}\n      </wpml:droneInfo>`
-      : '',
-    state.mission.payloadEnumValue !== ''
-      ? `<wpml:payloadInfo>\n        <wpml:payloadEnumValue>${state.mission.payloadEnumValue}</wpml:payloadEnumValue>\n        ${optionalTag(
-            'wpml:payloadPositionIndex',
-            state.mission.payloadPositionIndex,
-            '        ',
-          )}\n      </wpml:payloadInfo>`
-      : '',
-  ]
-    .filter(Boolean)
-    .join('\n      ');
-
-  const payloadParam = state.template.payloadParam;
-  const payloadParamInner = [
-    optionalTag('wpml:payloadPositionIndex', payloadParam.payloadPositionIndex, '        '),
-    optionalTag('wpml:focusMode', payloadParam.focusMode, '        '),
-    optionalTag('wpml:meteringMode', payloadParam.meteringMode, '        '),
-    optionalTag('wpml:dewarpingEnable', payloadParam.dewarpingEnable, '        '),
-    optionalTag('wpml:returnMode', payloadParam.returnMode, '        '),
-    optionalTag('wpml:samplingRate', payloadParam.samplingRate, '        '),
-    optionalTag('wpml:scanningMode', payloadParam.scanningMode, '        '),
-    optionalTag('wpml:modelColoringEnable', payloadParam.modelColoringEnable, '        '),
-    optionalTag('wpml:imageFormat', payloadParam.imageFormat, '        '),
-  ]
-    .filter(Boolean)
-    .join('\n');
-
-  const payloadParamXML = payloadParamInner
-    ? `<wpml:payloadParam>\n${payloadParamInner}\n      </wpml:payloadParam>`
-    : '';
+  const missionXML = createMissionXML();
+  const payloadParamXML = createPayloadParamXML();
 
   const folderXML = [
     `<wpml:templateType>${state.template.templateType}</wpml:templateType>`,
@@ -449,6 +417,237 @@ function generateKML() {
     </Folder>
   </Document>
 </kml>`;
+}
+
+function createMissionXML(indent = '      ') {
+  const missionLines = [
+    `${indent}<wpml:flyToWaylineMode>${state.mission.flyToWaylineMode}</wpml:flyToWaylineMode>`,
+    `${indent}<wpml:finishAction>${state.mission.finishAction}</wpml:finishAction>`,
+    `${indent}<wpml:exitOnRCLost>${state.mission.exitOnRCLost}</wpml:exitOnRCLost>`,
+    `${indent}<wpml:executeRCLostAction>${state.mission.executeRCLostAction}</wpml:executeRCLostAction>`,
+  ];
+
+  [
+    optionalTag('wpml:takeOffSecurityHeight', state.mission.takeOffSecurityHeight, indent),
+    optionalTag('wpml:takeOffRefPoint', state.mission.takeOffRefPoint, indent),
+    optionalTag('wpml:takeOffRefPointAGLHeight', state.mission.takeOffRefPointAGLHeight, indent),
+    optionalTag('wpml:globalTransitionalSpeed', state.mission.globalTransitionalSpeed, indent),
+    optionalTag('wpml:globalRTHHeight', state.mission.globalRTHHeight, indent),
+  ]
+    .filter(Boolean)
+    .forEach((line) => missionLines.push(line));
+
+  if (state.mission.droneEnumValue !== '') {
+    const innerIndent = `${indent}  `;
+    const droneLines = [
+      `${indent}<wpml:droneInfo>`,
+      `${innerIndent}<wpml:droneEnumValue>${state.mission.droneEnumValue}</wpml:droneEnumValue>`,
+    ];
+    const droneSub = optionalTag('wpml:droneSubEnumValue', state.mission.droneSubEnumValue, innerIndent);
+    if (droneSub) {
+      droneLines.push(droneSub);
+    }
+    droneLines.push(`${indent}</wpml:droneInfo>`);
+    missionLines.push(droneLines.join('\n'));
+  }
+
+  if (state.mission.payloadEnumValue !== '') {
+    const innerIndent = `${indent}  `;
+    const payloadLines = [
+      `${indent}<wpml:payloadInfo>`,
+      `${innerIndent}<wpml:payloadEnumValue>${state.mission.payloadEnumValue}</wpml:payloadEnumValue>`,
+    ];
+    const payloadIndex = optionalTag('wpml:payloadPositionIndex', state.mission.payloadPositionIndex, innerIndent);
+    if (payloadIndex) {
+      payloadLines.push(payloadIndex);
+    }
+    payloadLines.push(`${indent}</wpml:payloadInfo>`);
+    missionLines.push(payloadLines.join('\n'));
+  }
+
+  return missionLines.join('\n');
+}
+
+function createPayloadParamXML(indent = '      ') {
+  const payloadParam = state.template.payloadParam;
+  const innerIndent = `${indent}  `;
+  const payloadLines = [
+    optionalTag('wpml:payloadPositionIndex', payloadParam.payloadPositionIndex, innerIndent),
+    optionalTag('wpml:focusMode', payloadParam.focusMode, innerIndent),
+    optionalTag('wpml:meteringMode', payloadParam.meteringMode, innerIndent),
+    optionalTag('wpml:dewarpingEnable', payloadParam.dewarpingEnable, innerIndent),
+    optionalTag('wpml:returnMode', payloadParam.returnMode, innerIndent),
+    optionalTag('wpml:samplingRate', payloadParam.samplingRate, innerIndent),
+    optionalTag('wpml:scanningMode', payloadParam.scanningMode, innerIndent),
+    optionalTag('wpml:modelColoringEnable', payloadParam.modelColoringEnable, innerIndent),
+    optionalTag('wpml:imageFormat', payloadParam.imageFormat, innerIndent),
+  ].filter(Boolean);
+
+  if (payloadLines.length === 0) {
+    return '';
+  }
+
+  return [`${indent}<wpml:payloadParam>`, ...payloadLines, `${indent}</wpml:payloadParam>`].join('\n');
+}
+
+function createHeadingParamXML(source, indent = '        ') {
+  if (!source || !source.waypointHeadingMode) {
+    return '';
+  }
+
+  const headingLines = [
+    `${indent}<wpml:waypointHeadingParam>`,
+    `${indent}  <wpml:waypointHeadingMode>${source.waypointHeadingMode}</wpml:waypointHeadingMode>`,
+  ];
+
+  const angleLine = optionalTag('wpml:waypointHeadingAngle', source.waypointHeadingAngle, `${indent}  `);
+  if (angleLine) headingLines.push(angleLine);
+  const poiLine = optionalTag('wpml:waypointPoiPoint', source.waypointPoiPoint, `${indent}  `);
+  if (poiLine) headingLines.push(poiLine);
+  if (source.waypointHeadingPathMode) {
+    headingLines.push(
+      `${indent}  <wpml:waypointHeadingPathMode>${source.waypointHeadingPathMode}</wpml:waypointHeadingPathMode>`,
+    );
+  }
+
+  headingLines.push(`${indent}</wpml:waypointHeadingParam>`);
+  return headingLines.join('\n');
+}
+
+function createTurnParamXML(source, indent = '        ') {
+  if (!source || !source.waypointTurnMode) {
+    return '';
+  }
+
+  const turnLines = [
+    `${indent}<wpml:waypointTurnParam>`,
+    `${indent}  <wpml:waypointTurnMode>${source.waypointTurnMode}</wpml:waypointTurnMode>`,
+  ];
+
+  const dampingLine = optionalTag('wpml:waypointTurnDampingDist', source.waypointTurnDampingDist, `${indent}  `);
+  if (dampingLine) {
+    turnLines.push(dampingLine);
+  }
+
+  turnLines.push(`${indent}</wpml:waypointTurnParam>`);
+  return turnLines.join('\n');
+}
+
+function resolveExecuteHeightMode() {
+  if (state.template.surfaceFollowModeEnable) {
+    return 'realTimeFollowSurface';
+  }
+  if (state.template.heightMode === 'WGS84') {
+    return 'WGS84';
+  }
+  return 'relativeToStartPoint';
+}
+
+function generateWaylines() {
+  const missionXML = createMissionXML();
+  const payloadParamXML = createPayloadParamXML();
+  const waylineId = state.template.templateId === '' ? 0 : state.template.templateId;
+
+  const folderXML = [
+    optionalTag('wpml:templateId', state.template.templateId),
+    `<wpml:waylineId>${waylineId}</wpml:waylineId>`,
+    `<wpml:executeHeightMode>${resolveExecuteHeightMode()}</wpml:executeHeightMode>`,
+    optionalTag('wpml:autoFlightSpeed', state.template.autoFlightSpeed),
+    payloadParamXML,
+    state.waypoints
+      .map((waypoint, index) => {
+        const coordinates = [waypoint.longitude, waypoint.latitude];
+        if (Number.isFinite(waypoint.coordinateAltitude)) {
+          coordinates.push(waypoint.coordinateAltitude);
+        }
+
+        const executeHeight = waypoint.useGlobalHeight ? state.template.globalHeight : waypoint.height;
+        const waypointSpeed = waypoint.useGlobalSpeed ? state.template.autoFlightSpeed : waypoint.waypointSpeed;
+        const headingSource = waypoint.useGlobalHeadingParam
+          ? {
+              waypointHeadingMode: state.template.waypointHeadingMode,
+              waypointHeadingAngle: state.template.waypointHeadingAngle,
+              waypointPoiPoint: state.template.waypointPoiPoint,
+              waypointHeadingPathMode: state.template.waypointHeadingPathMode,
+            }
+          : waypoint;
+        const turnSource = waypoint.useGlobalTurnParam
+          ? {
+              waypointTurnMode: state.template.globalWaypointTurnMode,
+              waypointTurnDampingDist: '',
+            }
+          : waypoint;
+        const useStraightLineValue = waypoint.useGlobalTurnParam
+          ? state.template.globalUseStraightLine
+          : waypoint.useStraightLine;
+
+        const headingParamXML = createHeadingParamXML(headingSource, '        ');
+        const turnParamXML = createTurnParamXML(turnSource, '        ');
+
+        const lines = [
+          '      <Placemark>',
+          `        <name>${escapeXML(waypoint.name)}</name>`,
+          optionalTag('description', waypoint.description, '        '),
+          '        <Point>',
+          `          <coordinates>${coordinates.join(',')}</coordinates>`,
+          '        </Point>',
+          `        <wpml:index>${index}</wpml:index>`,
+        ];
+
+        const ellipsoidLine = optionalTag('wpml:ellipsoidHeight', waypoint.ellipsoidHeight, '        ');
+        if (ellipsoidLine) lines.push(ellipsoidLine);
+
+        const executeHeightLine = optionalTag('wpml:executeHeight', executeHeight, '        ');
+        if (executeHeightLine) lines.push(executeHeightLine);
+
+        const speedLine = optionalTag('wpml:waypointSpeed', waypointSpeed, '        ');
+        if (speedLine) lines.push(speedLine);
+
+        if (headingParamXML) lines.push(headingParamXML);
+        if (turnParamXML) lines.push(turnParamXML);
+
+        lines.push(`        <wpml:useStraightLine>${useStraightLineValue ? 1 : 0}</wpml:useStraightLine>`);
+        lines.push(`        <wpml:isRisky>${waypoint.isRisky ? 1 : 0}</wpml:isRisky>`);
+
+        const gimbalLine = optionalTag('wpml:gimbalPitchAngle', waypoint.gimbalPitchAngle, '        ');
+        if (gimbalLine) lines.push(gimbalLine);
+
+        lines.push('      </Placemark>');
+        return lines.filter(Boolean).join('\n');
+      })
+      .join('\n'),
+  ]
+    .filter(Boolean)
+    .join('\n      ');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:wpml="http://www.dji.com/wpmz/1.0.2">
+  <Document>
+    <wpml:missionConfig>
+      ${missionXML}
+    </wpml:missionConfig>
+    <Folder>
+      ${folderXML}
+    </Folder>
+  </Document>
+</kml>`;
+}
+
+function updateXMLPreview() {
+  if (!templatePreview || !waylinesPreview) {
+    return;
+  }
+
+  const templateXML = generateKML().trim();
+  templatePreview.textContent = templateXML || TEMPLATE_PREVIEW_PLACEHOLDER;
+
+  if (state.waypoints.length === 0) {
+    waylinesPreview.textContent = WAYLINES_PREVIEW_PLACEHOLDER;
+    return;
+  }
+
+  const waylinesXML = generateWaylines().trim();
+  waylinesPreview.textContent = waylinesXML || WAYLINES_PREVIEW_PLACEHOLDER;
 }
 
 function optionalTag(tagName, value, indent = '      ') {

--- a/index.html
+++ b/index.html
@@ -20,6 +20,19 @@
     <div class="workspace-grid">
       <div class="workspace-forms">
         <section class="card">
+          <h2>0. 导入已有模板（可选）</h2>
+          <p class="hint">
+            如需继续编辑既有航线，可在此选择 <code>template.kmz</code> 或 <code>template.kml</code> 文件，系统会解析
+            XML 并回填到左侧表单中。
+          </p>
+          <label class="file-input">
+            <span class="label-title">选择文件</span>
+            <input type="file" id="kmzInput" accept=".kmz,.kml" />
+          </label>
+          <p class="hint">导入会覆盖当前表单与航点，请在导入前确认需要保留的数据已保存。</p>
+        </section>
+
+        <section class="card">
       <h2>1. 创建信息</h2>
       <form id="creationForm" class="stack">
         <div class="field-grid">

--- a/index.html
+++ b/index.html
@@ -22,15 +22,18 @@
       <form id="creationForm" class="stack">
         <div class="field-grid">
           <label>
-            文件作者（<code>&lt;wpml:author&gt;</code>）
+            <span class="label-title">文件作者（<code>&lt;wpml:author&gt;</code>）</span>
+            <span class="field-hint">填写模板的创建者或单位名称，便于在任务记录中追溯来源。</span>
             <input type="text" name="author" placeholder="示例：Cloud API" />
           </label>
           <label>
-            创建时间（ms，<code>&lt;wpml:createTime&gt;</code>）
+            <span class="label-title">创建时间（ms，<code>&lt;wpml:createTime&gt;</code>）</span>
+            <span class="field-hint">使用 Unix 时间戳（毫秒）表示模板首次生成的时间，例如 <code>Date.now()</code>。</span>
             <input type="number" name="createTime" inputmode="numeric" />
           </label>
           <label>
-            更新时间（ms，<code>&lt;wpml:updateTime&gt;</code>）
+            <span class="label-title">更新时间（ms，<code>&lt;wpml:updateTime&gt;</code>）</span>
+            <span class="field-hint">同样以 Unix 毫秒时间戳记录模板最近一次更新的时间。</span>
             <input type="number" name="updateTime" inputmode="numeric" />
           </label>
         </div>
@@ -48,14 +51,16 @@
       <form id="missionForm" class="stack">
         <div class="field-grid">
           <label>
-            飞向首航点模式
+            <span class="label-title">飞向首航点模式</span>
+            <span class="field-hint">指定飞机起飞后前往第一个航点时的姿态策略，选择“safely”可确保爬升到安全高度后再前往航点。</span>
             <select name="flyToWaylineMode">
               <option value="safely">safely</option>
               <option value="pointToPoint">pointToPoint</option>
             </select>
           </label>
           <label>
-            航线结束动作
+            <span class="label-title">航线结束动作</span>
+            <span class="field-hint">定义所有航点执行完毕后飞机应采取的动作，例如自动返航或原地悬停。</span>
             <select name="finishAction">
               <option value="goHome">goHome</option>
               <option value="noAction">noAction</option>
@@ -64,14 +69,16 @@
             </select>
           </label>
           <label>
-            失控是否继续执行航线
+            <span class="label-title">失控是否继续执行航线</span>
+            <span class="field-hint">当遥控链路丢失时，决定是否继续当前航线（goContinue）或立即按失控动作处理。</span>
             <select name="exitOnRCLost">
               <option value="goContinue">goContinue</option>
               <option value="executeLostAction">executeLostAction</option>
             </select>
           </label>
           <label>
-            失控动作
+            <span class="label-title">失控动作</span>
+            <span class="field-hint">当选择执行失控动作时，将触发的具体行为，例如悬停、返航或降落。</span>
             <select name="executeRCLostAction">
               <option value="hover">hover</option>
               <option value="goHome">goHome</option>
@@ -79,39 +86,48 @@
             </select>
           </label>
           <label>
-            安全起飞高度（m）
+            <span class="label-title">安全起飞高度（m）</span>
+            <span class="field-hint">飞机起飞后需上升至的最小安全高度，满足文档要求的 <code>&lt;wpml:takeOffSecurityHeight&gt;</code>。</span>
             <input type="number" name="takeOffSecurityHeight" step="any" />
           </label>
           <label>
-            起飞参考点（lon,lat,height）
+            <span class="label-title">起飞参考点（lon,lat,height）</span>
+            <span class="field-hint">填写经度、纬度、椭球高度，作为航线坐标系参考点，例如 <code>116.54,39.79,50</code>。</span>
             <input type="text" name="takeOffRefPoint" placeholder="示例：23.98057,115.987663,100" />
           </label>
           <label>
-            起飞参考点 AGL 高度（m）
+            <span class="label-title">起飞参考点 AGL 高度（m）</span>
+            <span class="field-hint">文档中的 <code>&lt;wpml:takeOffRefPointAGLHeight&gt;</code>，记录起飞点与地面的相对高度。</span>
             <input type="number" name="takeOffRefPointAGLHeight" step="any" />
           </label>
           <label>
-            全局过渡速度（m/s）
+            <span class="label-title">全局过渡速度（m/s）</span>
+            <span class="field-hint">航点之间的默认过渡速度，对应 <code>&lt;wpml:globalTransitionalSpeed&gt;</code>。</span>
             <input type="number" name="globalTransitionalSpeed" step="any" />
           </label>
           <label>
-            全局返航高度（m）
+            <span class="label-title">全局返航高度（m）</span>
+            <span class="field-hint">返航时保持的全局高度 <code>&lt;wpml:globalRTHHeight&gt;</code>，确保避开障碍。</span>
             <input type="number" name="globalRTHHeight" step="any" />
           </label>
           <label>
-            机型枚举值
+            <span class="label-title">机型枚举值</span>
+            <span class="field-hint">填写文档提供的飞行器枚举编号（<code>&lt;wpml:droneEnumValue&gt;</code>），例如 M300 对应 67。</span>
             <input type="number" name="droneEnumValue" />
           </label>
           <label>
-            机型子枚举值
+            <span class="label-title">机型子枚举值</span>
+            <span class="field-hint">部分机型需要填写子枚举（<code>&lt;wpml:droneSubEnumValue&gt;</code>），没有则填 0。</span>
             <input type="number" name="droneSubEnumValue" />
           </label>
           <label>
-            载荷枚举值
+            <span class="label-title">载荷枚举值</span>
+            <span class="field-hint">根据 Cloud API 枚举填写负载型号（<code>&lt;wpml:payloadEnumValue&gt;</code>），如禅思 H20T 为 67。</span>
             <input type="number" name="payloadEnumValue" />
           </label>
           <label>
-            载荷挂载位置
+            <span class="label-title">载荷挂载位置</span>
+            <span class="field-hint">与枚举组合使用，标明挂载在机身的索引（<code>&lt;wpml:payloadPositionIndex&gt;</code>）。</span>
             <input type="number" name="payloadPositionIndex" />
           </label>
         </div>
@@ -128,7 +144,8 @@
       <form id="templateForm" class="stack">
         <div class="field-grid">
           <label>
-            模板类型
+            <span class="label-title">模板类型</span>
+            <span class="field-hint">选择文档定义的 <code>&lt;wpml:templateType&gt;</code>，决定任务为航点、二维测绘等模式。</span>
             <select name="templateType">
               <option value="waypoint">waypoint</option>
               <option value="mapping2d">mapping2d</option>
@@ -137,59 +154,72 @@
             </select>
           </label>
           <label>
-            模板 ID
+            <span class="label-title">模板 ID</span>
+            <span class="field-hint">填写模板唯一标识 <code>&lt;wpml:templateId&gt;</code>，需与企业侧模板管理保持一致。</span>
             <input type="number" name="templateId" min="0" />
           </label>
           <label>
-            坐标模式
+            <span class="label-title">坐标模式</span>
+            <span class="field-hint">指明航点使用的地理坐标系，如国际通用 WGS84 或国内 CGCS2000。</span>
             <select name="coordinateMode">
               <option value="WGS84">WGS84</option>
               <option value="CGCS2000">CGCS2000</option>
             </select>
           </label>
           <label>
-            高程模式
+            <span class="label-title">高程模式</span>
+            <span class="field-hint">对应 <code>&lt;wpml:heightMode&gt;</code>，用于指定椭球基准面（如 EGM96 大地水准面）。</span>
             <select name="heightMode">
               <option value="EGM96">EGM96</option>
               <option value="WGS84">WGS84</option>
             </select>
           </label>
           <label>
-            全局拍摄高度（m）
+            <span class="label-title">全局拍摄高度（m）</span>
+            <span class="field-hint">模板默认的拍摄高度 <code>&lt;wpml:globalShootHeight&gt;</code>，适用于继承模板设置的航点。</span>
             <input type="number" name="globalShootHeight" step="any" />
           </label>
           <label>
-            全局航线高度（m）
+            <span class="label-title">全局航线高度（m）</span>
+            <span class="field-hint">必填的 <code>&lt;wpml:globalHeight&gt;</code>，为航点继承高度的基准值。</span>
             <input type="number" name="globalHeight" step="any" />
           </label>
           <label>
-            定位类型
+            <span class="label-title">定位类型</span>
+            <span class="field-hint">选择 GPS 或 RTK 等定位精度模式，对应 <code>&lt;wpml:positioningType&gt;</code>。</span>
             <select name="positioningType">
               <option value="GPS">GPS</option>
               <option value="RTK">RTK</option>
             </select>
           </label>
           <label class="checkbox">
-            <input type="checkbox" name="surfaceFollowModeEnable" />
-            <span>开启地形跟随模式</span>
+            <span class="checkbox-main">
+              <input type="checkbox" name="surfaceFollowModeEnable" />
+              <span class="label-title">开启地形跟随模式</span>
+            </span>
+            <span class="field-hint">勾选后启用 <code>&lt;wpml:surfaceFollowModeEnable&gt;</code>，航点高度基于地形进行动态调整。</span>
           </label>
           <label>
-            地形相对高度（m）
+            <span class="label-title">地形相对高度（m）</span>
+            <span class="field-hint">在地形跟随开启时生效，设置与地表的相对高度 <code>&lt;wpml:surfaceRelativeHeight&gt;</code>。</span>
             <input type="number" name="surfaceRelativeHeight" step="any" />
           </label>
           <label>
-            自动飞行速度（m/s）
+            <span class="label-title">自动飞行速度（m/s）</span>
+            <span class="field-hint">航线执行时默认速度 <code>&lt;wpml:autoFlightSpeed&gt;</code>，航点可选择继承或覆盖。</span>
             <input type="number" name="autoFlightSpeed" step="any" />
           </label>
           <label>
-            云台俯仰模式
+            <span class="label-title">云台俯仰模式</span>
+            <span class="field-hint">控制云台俯仰角来源，选择沿用航点自定义或模板统一设置。</span>
             <select name="gimbalPitchMode">
               <option value="usePointSetting">usePointSetting</option>
               <option value="useTemplateSetting">useTemplateSetting</option>
             </select>
           </label>
           <label>
-            航点偏航模式
+            <span class="label-title">航点偏航模式</span>
+            <span class="field-hint">模板级偏航策略 <code>&lt;wpml:waypointHeadingMode&gt;</code>，决定机头指向方式。</span>
             <select name="waypointHeadingMode">
               <option value="followWayline">followWayline</option>
               <option value="manually">manually</option>
@@ -199,15 +229,18 @@
             </select>
           </label>
           <label>
-            航点偏航角（°）
+            <span class="label-title">航点偏航角（°）</span>
+            <span class="field-hint">当偏航模式为 fixed/manual 时指定机头角度，对应 <code>&lt;wpml:waypointHeadingAngle&gt;</code>。</span>
             <input type="number" name="waypointHeadingAngle" step="any" />
           </label>
           <label>
-            POI 点（lon,lat,height）
+            <span class="label-title">POI 点（lon,lat,height）</span>
+            <span class="field-hint">当朝向兴趣点时需填写经纬高坐标，对应 <code>&lt;wpml:waypointPoiPoint&gt;</code>。</span>
             <input type="text" name="waypointPoiPoint" />
           </label>
           <label>
-            航点偏航路径模式
+            <span class="label-title">航点偏航路径模式</span>
+            <span class="field-hint">定义偏航角变化方向（顺时针/逆时针）或跟随最短弧度。</span>
             <select name="waypointHeadingPathMode">
               <option value="clockwise">clockwise</option>
               <option value="counterClockwise">counterClockwise</option>
@@ -215,7 +248,8 @@
             </select>
           </label>
           <label>
-            转弯模式
+            <span class="label-title">转弯模式</span>
+            <span class="field-hint">模板级转弯控制 <code>&lt;wpml:globalWaypointTurnMode&gt;</code>，决定飞机经过航点的方式。</span>
             <select name="globalWaypointTurnMode">
               <option value="coordinateTurn">coordinateTurn</option>
               <option value="toPointAndStopWithDiscontinuityCurvature">toPointAndStopWithDiscontinuityCurvature</option>
@@ -224,19 +258,24 @@
             </select>
           </label>
           <label class="checkbox">
-            <input type="checkbox" name="globalUseStraightLine" />
-            <span>航点间使用直线</span>
+            <span class="checkbox-main">
+              <input type="checkbox" name="globalUseStraightLine" />
+              <span class="label-title">航点间使用直线</span>
+            </span>
+            <span class="field-hint">启用后 <code>&lt;wpml:globalUseStraightLine&gt;</code> 强制航点间按直线连接，不使用弧线过渡。</span>
           </label>
         </div>
         <div class="subsection">
           <h3>负载参数（<code>&lt;wpml:payloadParam&gt;</code>）</h3>
           <div class="field-grid">
             <label>
-              负载挂载位置
+              <span class="label-title">负载挂载位置</span>
+              <span class="field-hint">负载参数内的挂载索引，与任务配置保持一致。</span>
               <input type="number" name="payloadParam.payloadPositionIndex" min="0" />
             </label>
             <label>
-              对焦模式
+              <span class="label-title">对焦模式</span>
+              <span class="field-hint">可选的 <code>&lt;wpml:focusMode&gt;</code>，例如首帧对焦或自定义。</span>
               <select name="payloadParam.focusMode">
                 <option value="">（可选）</option>
                 <option value="firstPoint">firstPoint</option>
@@ -244,7 +283,8 @@
               </select>
             </label>
             <label>
-              测光模式
+              <span class="label-title">测光模式</span>
+              <span class="field-hint">选择相机测光策略 <code>&lt;wpml:meteringMode&gt;</code>。</span>
               <select name="payloadParam.meteringMode">
                 <option value="">（可选）</option>
                 <option value="average">average</option>
@@ -252,7 +292,8 @@
               </select>
             </label>
             <label>
-              畸变矫正
+              <span class="label-title">畸变矫正</span>
+              <span class="field-hint">是否开启镜头畸变矫正 <code>&lt;wpml:dewarpingEnable&gt;</code>。</span>
               <select name="payloadParam.dewarpingEnable">
                 <option value="">（可选）</option>
                 <option value="0">0</option>
@@ -260,7 +301,8 @@
               </select>
             </label>
             <label>
-              激光雷达回波模式
+              <span class="label-title">激光雷达回波模式</span>
+              <span class="field-hint">用于激光雷达负载的回波模式 <code>&lt;wpml:returnMode&gt;</code>。</span>
               <select name="payloadParam.returnMode">
                 <option value="">（可选）</option>
                 <option value="singleReturnStrongest">singleReturnStrongest</option>
@@ -269,11 +311,13 @@
               </select>
             </label>
             <label>
-              负载采样率（Hz）
+              <span class="label-title">负载采样率（Hz）</span>
+              <span class="field-hint">指定负载采样频率 <code>&lt;wpml:samplingRate&gt;</code>。</span>
               <input type="number" name="payloadParam.samplingRate" step="1" min="0" />
             </label>
             <label>
-              扫描模式
+              <span class="label-title">扫描模式</span>
+              <span class="field-hint">激光雷达扫描策略 <code>&lt;wpml:scanningMode&gt;</code>，如重复或非重复。</span>
               <select name="payloadParam.scanningMode">
                 <option value="">（可选）</option>
                 <option value="repetitive">repetitive</option>
@@ -281,7 +325,8 @@
               </select>
             </label>
             <label>
-              真彩上色
+              <span class="label-title">真彩上色</span>
+              <span class="field-hint">控制建模是否启用真彩上色 <code>&lt;wpml:modelColoringEnable&gt;</code>。</span>
               <select name="payloadParam.modelColoringEnable">
                 <option value="">（可选）</option>
                 <option value="0">0</option>
@@ -289,7 +334,8 @@
               </select>
             </label>
             <label>
-              图片格式列表（逗号分隔）
+              <span class="label-title">图片格式列表（逗号分隔）</span>
+              <span class="field-hint">配置相机输出的图像格式 <code>&lt;wpml:imageFormat&gt;</code>，如 <code>wide,zoom</code>。</span>
               <input type="text" name="payloadParam.imageFormat" placeholder="例如：wide,zoom" />
             </label>
           </div>
@@ -308,71 +354,98 @@
         <form id="waypointForm" class="stack">
           <input type="hidden" name="editIndex" />
           <label>
-            航点名称（<code>&lt;name&gt;</code>）
+            <span class="label-title">航点名称（<code>&lt;name&gt;</code>）</span>
+            <span class="field-hint">显示在列表与 KML <code>&lt;name&gt;</code> 中的标题，建议按顺序命名。</span>
             <input type="text" name="name" required placeholder="示例：航点 1" />
           </label>
           <label>
-            描述（可选）
+            <span class="label-title">描述（可选）</span>
+            <span class="field-hint">写入 <code>&lt;description&gt;</code>，用于补充任务备注。</span>
             <textarea name="description" rows="2" placeholder="补充说明"></textarea>
           </label>
           <div class="field-grid">
             <label>
-              经度
+              <span class="label-title">经度</span>
+              <span class="field-hint">航点 <code>&lt;coordinates&gt;</code> 中的经度（度），需符合所选坐标系。</span>
               <input type="number" name="longitude" step="any" required />
             </label>
             <label>
-              纬度
+              <span class="label-title">纬度</span>
+              <span class="field-hint">航点 <code>&lt;coordinates&gt;</code> 中的纬度（度）。</span>
               <input type="number" name="latitude" step="any" required />
             </label>
             <label>
-              高程（可选，写入 <code>&lt;coordinates&gt;</code>）
+              <span class="label-title">高程（可选，写入 <code>&lt;coordinates&gt;</code>）</span>
+              <span class="field-hint">需要时可写入坐标高度分量，不同于 AGL/椭球高度。</span>
               <input type="number" name="coordinateAltitude" step="any" />
             </label>
           </div>
           <div class="field-grid">
             <label>
-              椭球高度（m，<code>&lt;wpml:ellipsoidHeight&gt;</code>）
+              <span class="label-title">椭球高度（m，<code>&lt;wpml:ellipsoidHeight&gt;</code>）</span>
+              <span class="field-hint">基于选定椭球的高度，常用于机载导航。</span>
               <input type="number" name="ellipsoidHeight" step="any" />
             </label>
             <label>
-              AGL 高度（m，<code>&lt;wpml:height&gt;</code>）
+              <span class="label-title">AGL 高度（m，<code>&lt;wpml:height&gt;</code>）</span>
+              <span class="field-hint">相对地面的高度，可根据“继承全局高度”自动填充。</span>
               <input type="number" name="height" step="any" />
             </label>
             <label>
-              云台俯仰角（°，<code>&lt;wpml:gimbalPitchAngle&gt;</code>）
+              <span class="label-title">云台俯仰角（°，<code>&lt;wpml:gimbalPitchAngle&gt;</code>）</span>
+              <span class="field-hint">控制该航点执行时的云台俯仰角度。</span>
               <input type="number" name="gimbalPitchAngle" step="any" />
             </label>
           </div>
           <div class="field-grid">
             <label class="checkbox">
-              <input type="checkbox" name="useGlobalHeight" checked />
-              <span>继承全局高度</span>
+              <span class="checkbox-main">
+                <input type="checkbox" name="useGlobalHeight" checked />
+                <span class="label-title">继承全局高度</span>
+              </span>
+              <span class="field-hint">选中时使用模板 <code>&lt;wpml:globalHeight&gt;</code>，取消后需填写本航点高度。</span>
             </label>
             <label class="checkbox">
-              <input type="checkbox" name="useGlobalSpeed" checked />
-              <span>继承全局速度</span>
+              <span class="checkbox-main">
+                <input type="checkbox" name="useGlobalSpeed" checked />
+                <span class="label-title">继承全局速度</span>
+              </span>
+              <span class="field-hint">沿用 <code>&lt;wpml:autoFlightSpeed&gt;</code>，取消后可设置单点速度。</span>
             </label>
             <label class="checkbox">
-              <input type="checkbox" name="useGlobalHeadingParam" checked />
-              <span>继承全局偏航参数</span>
+              <span class="checkbox-main">
+                <input type="checkbox" name="useGlobalHeadingParam" checked />
+                <span class="label-title">继承全局偏航参数</span>
+              </span>
+              <span class="field-hint">遵循模板级偏航设置，取消后可自定义 <code>&lt;wpml:waypointHeadingParam&gt;</code>。</span>
             </label>
             <label class="checkbox">
-              <input type="checkbox" name="useGlobalTurnParam" checked />
-              <span>继承全局转弯参数</span>
+              <span class="checkbox-main">
+                <input type="checkbox" name="useGlobalTurnParam" checked />
+                <span class="label-title">继承全局转弯参数</span>
+              </span>
+              <span class="field-hint">使用全局转弯模式，取消后填写本航点的 <code>&lt;wpml:waypointTurnParam&gt;</code>。</span>
             </label>
             <label class="checkbox">
-              <input type="checkbox" name="useStraightLine" />
-              <span>航段贴合直线</span>
+              <span class="checkbox-main">
+                <input type="checkbox" name="useStraightLine" />
+                <span class="label-title">航段贴合直线</span>
+              </span>
+              <span class="field-hint">对当前航段设置 <code>&lt;wpml:useStraightLine&gt;</code>，无需继承模板。</span>
             </label>
             <label class="checkbox">
-              <input type="checkbox" name="isRisky" />
-              <span>标记为危险点</span>
+              <span class="checkbox-main">
+                <input type="checkbox" name="isRisky" />
+                <span class="label-title">标记为危险点</span>
+              </span>
+              <span class="field-hint">标记 <code>&lt;wpml:isRisky&gt;</code>，提醒执行人员注意危险航点。</span>
             </label>
           </div>
           <div class="subsection">
             <h3>航点速度（<code>&lt;wpml:waypointSpeed&gt;</code>）</h3>
             <label>
-              当不继承全局速度时的目标速度（m/s）
+              <span class="label-title">当不继承全局速度时的目标速度（m/s）</span>
+              <span class="field-hint">设置 <code>&lt;wpml:waypointSpeed&gt;</code> 的数值，覆盖全局飞行速度。</span>
               <input type="number" name="waypointSpeed" step="any" />
             </label>
           </div>
@@ -380,7 +453,8 @@
             <h3>航点偏航参数（<code>&lt;wpml:waypointHeadingParam&gt;</code>）</h3>
             <div class="field-grid">
               <label>
-                偏航模式
+                <span class="label-title">偏航模式</span>
+                <span class="field-hint">航点独立的偏航策略，如面向航线或兴趣点。</span>
                 <select name="waypointHeadingMode">
                   <option value="followWayline">followWayline</option>
                   <option value="manually">manually</option>
@@ -390,15 +464,18 @@
                 </select>
               </label>
               <label>
-                偏航角（°）
+                <span class="label-title">偏航角（°）</span>
+                <span class="field-hint">对应 <code>&lt;wpml:waypointHeadingAngle&gt;</code>，在固定角模式下填写。</span>
                 <input type="number" name="waypointHeadingAngle" step="any" />
               </label>
               <label>
-                兴趣点（lat,lon,height）
+                <span class="label-title">兴趣点（lat,lon,height）</span>
+                <span class="field-hint">当朝向 POI 时需提供坐标 <code>&lt;wpml:waypointPoiPoint&gt;</code>。</span>
                 <input type="text" name="waypointPoiPoint" placeholder="例如：23.98,115.98,0" />
               </label>
               <label>
-                偏航转动方向
+                <span class="label-title">偏航转动方向</span>
+                <span class="field-hint">设置偏航角变化方向 <code>&lt;wpml:waypointHeadingPathMode&gt;</code>。</span>
                 <select name="waypointHeadingPathMode">
                   <option value="clockwise">clockwise</option>
                   <option value="counterClockwise">counterClockwise</option>
@@ -411,7 +488,8 @@
             <h3>航点转弯参数（<code>&lt;wpml:waypointTurnParam&gt;</code>）</h3>
             <div class="field-grid">
               <label>
-                转弯模式
+                <span class="label-title">转弯模式</span>
+                <span class="field-hint">针对该航点的转弯策略 <code>&lt;wpml:waypointTurnMode&gt;</code>。</span>
                 <select name="waypointTurnMode">
                   <option value="coordinateTurn">coordinateTurn</option>
                   <option value="toPointAndStopWithDiscontinuityCurvature">toPointAndStopWithDiscontinuityCurvature</option>
@@ -420,7 +498,8 @@
                 </select>
               </label>
               <label>
-                转弯截距（m）
+                <span class="label-title">转弯截距（m）</span>
+                <span class="field-hint">对应 <code>&lt;wpml:waypointTurnDampingDist&gt;</code>，调节提前转弯距离。</span>
                 <input type="number" name="waypointTurnDampingDist" step="any" />
               </label>
             </div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KMZ 模板参数可视化表单</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>DJI Waylines 模板表单编辑器</h1>
+    <p>
+      按照 Cloud API 文档模板，从零开始逐项填写 <code>template.kml</code> 的参数，实时生成可下载的
+      KML/KMZ 文件。
+    </p>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>1. 创建信息</h2>
+      <form id="creationForm" class="stack">
+        <div class="field-grid">
+          <label>
+            文件作者（<code>&lt;wpml:author&gt;</code>）
+            <input type="text" name="author" placeholder="示例：Cloud API" />
+          </label>
+          <label>
+            创建时间（ms，<code>&lt;wpml:createTime&gt;</code>）
+            <input type="number" name="createTime" inputmode="numeric" />
+          </label>
+          <label>
+            更新时间（ms，<code>&lt;wpml:updateTime&gt;</code>）
+            <input type="number" name="updateTime" inputmode="numeric" />
+          </label>
+        </div>
+        <div class="actions">
+          <button type="button" id="creationNow" class="secondary">使用当前时间戳</button>
+          <div class="spacer"></div>
+          <button type="submit">保存创建信息</button>
+        </div>
+      </form>
+      <p id="creationStatus" class="status"></p>
+    </section>
+
+    <section class="card">
+      <h2>2. 任务配置（<code>&lt;wpml:missionConfig&gt;</code>）</h2>
+      <form id="missionForm" class="stack">
+        <div class="field-grid">
+          <label>
+            飞向首航点模式
+            <select name="flyToWaylineMode">
+              <option value="safely">safely</option>
+              <option value="pointToPoint">pointToPoint</option>
+            </select>
+          </label>
+          <label>
+            航线结束动作
+            <select name="finishAction">
+              <option value="goHome">goHome</option>
+              <option value="noAction">noAction</option>
+              <option value="autoLand">autoLand</option>
+              <option value="gotoFirstWaypoint">gotoFirstWaypoint</option>
+            </select>
+          </label>
+          <label>
+            失控是否继续执行航线
+            <select name="exitOnRCLost">
+              <option value="goContinue">goContinue</option>
+              <option value="executeLostAction">executeLostAction</option>
+            </select>
+          </label>
+          <label>
+            失控动作
+            <select name="executeRCLostAction">
+              <option value="hover">hover</option>
+              <option value="goHome">goHome</option>
+              <option value="land">land</option>
+            </select>
+          </label>
+          <label>
+            安全起飞高度（m）
+            <input type="number" name="takeOffSecurityHeight" step="any" />
+          </label>
+          <label>
+            起飞参考点（lon,lat,height）
+            <input type="text" name="takeOffRefPoint" placeholder="示例：23.98057,115.987663,100" />
+          </label>
+          <label>
+            起飞参考点 AGL 高度（m）
+            <input type="number" name="takeOffRefPointAGLHeight" step="any" />
+          </label>
+          <label>
+            全局过渡速度（m/s）
+            <input type="number" name="globalTransitionalSpeed" step="any" />
+          </label>
+          <label>
+            全局返航高度（m）
+            <input type="number" name="globalRTHHeight" step="any" />
+          </label>
+          <label>
+            机型枚举值
+            <input type="number" name="droneEnumValue" />
+          </label>
+          <label>
+            机型子枚举值
+            <input type="number" name="droneSubEnumValue" />
+          </label>
+          <label>
+            载荷枚举值
+            <input type="number" name="payloadEnumValue" />
+          </label>
+          <label>
+            载荷挂载位置
+            <input type="number" name="payloadPositionIndex" />
+          </label>
+        </div>
+        <div class="actions">
+          <div class="spacer"></div>
+          <button type="submit">保存任务信息</button>
+        </div>
+      </form>
+      <p id="missionStatus" class="status"></p>
+    </section>
+
+    <section class="card">
+      <h2>3. 模板参数（<code>&lt;Folder&gt;</code>）</h2>
+      <form id="templateForm" class="stack">
+        <div class="field-grid">
+          <label>
+            模板类型
+            <select name="templateType">
+              <option value="waypoint">waypoint</option>
+              <option value="mapping2d">mapping2d</option>
+              <option value="mapping3d">mapping3d</option>
+              <option value="mappingStrip">mappingStrip</option>
+            </select>
+          </label>
+          <label>
+            模板 ID
+            <input type="number" name="templateId" min="0" />
+          </label>
+          <label>
+            坐标模式
+            <select name="coordinateMode">
+              <option value="WGS84">WGS84</option>
+              <option value="CGCS2000">CGCS2000</option>
+            </select>
+          </label>
+          <label>
+            高程模式
+            <select name="heightMode">
+              <option value="EGM96">EGM96</option>
+              <option value="WGS84">WGS84</option>
+            </select>
+          </label>
+          <label>
+            全局拍摄高度（m）
+            <input type="number" name="globalShootHeight" step="any" />
+          </label>
+          <label>
+            全局航线高度（m）
+            <input type="number" name="globalHeight" step="any" />
+          </label>
+          <label>
+            定位类型
+            <select name="positioningType">
+              <option value="GPS">GPS</option>
+              <option value="RTK">RTK</option>
+            </select>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="surfaceFollowModeEnable" />
+            <span>开启地形跟随模式</span>
+          </label>
+          <label>
+            地形相对高度（m）
+            <input type="number" name="surfaceRelativeHeight" step="any" />
+          </label>
+          <label>
+            自动飞行速度（m/s）
+            <input type="number" name="autoFlightSpeed" step="any" />
+          </label>
+          <label>
+            云台俯仰模式
+            <select name="gimbalPitchMode">
+              <option value="usePointSetting">usePointSetting</option>
+              <option value="useTemplateSetting">useTemplateSetting</option>
+            </select>
+          </label>
+          <label>
+            航点偏航模式
+            <select name="waypointHeadingMode">
+              <option value="followWayline">followWayline</option>
+              <option value="manually">manually</option>
+              <option value="fixed">fixed</option>
+              <option value="smoothTransition">smoothTransition</option>
+              <option value="towardPOI">towardPOI</option>
+            </select>
+          </label>
+          <label>
+            航点偏航角（°）
+            <input type="number" name="waypointHeadingAngle" step="any" />
+          </label>
+          <label>
+            POI 点（lon,lat,height）
+            <input type="text" name="waypointPoiPoint" />
+          </label>
+          <label>
+            航点偏航路径模式
+            <select name="waypointHeadingPathMode">
+              <option value="clockwise">clockwise</option>
+              <option value="counterClockwise">counterClockwise</option>
+              <option value="followBadArc">followBadArc</option>
+            </select>
+          </label>
+          <label>
+            转弯模式
+            <select name="globalWaypointTurnMode">
+              <option value="coordinateTurn">coordinateTurn</option>
+              <option value="toPointAndStopWithDiscontinuityCurvature">toPointAndStopWithDiscontinuityCurvature</option>
+              <option value="toPointAndStopWithContinuityCurvature">toPointAndStopWithContinuityCurvature</option>
+              <option value="toPointAndPassWithContinuityCurvature">toPointAndPassWithContinuityCurvature</option>
+            </select>
+          </label>
+          <label class="checkbox">
+            <input type="checkbox" name="globalUseStraightLine" />
+            <span>航点间使用直线</span>
+          </label>
+        </div>
+        <div class="subsection">
+          <h3>负载参数（<code>&lt;wpml:payloadParam&gt;</code>）</h3>
+          <div class="field-grid">
+            <label>
+              负载挂载位置
+              <input type="number" name="payloadParam.payloadPositionIndex" min="0" />
+            </label>
+            <label>
+              对焦模式
+              <select name="payloadParam.focusMode">
+                <option value="">（可选）</option>
+                <option value="firstPoint">firstPoint</option>
+                <option value="custom">custom</option>
+              </select>
+            </label>
+            <label>
+              测光模式
+              <select name="payloadParam.meteringMode">
+                <option value="">（可选）</option>
+                <option value="average">average</option>
+                <option value="spot">spot</option>
+              </select>
+            </label>
+            <label>
+              畸变矫正
+              <select name="payloadParam.dewarpingEnable">
+                <option value="">（可选）</option>
+                <option value="0">0</option>
+                <option value="1">1</option>
+              </select>
+            </label>
+            <label>
+              激光雷达回波模式
+              <select name="payloadParam.returnMode">
+                <option value="">（可选）</option>
+                <option value="singleReturnStrongest">singleReturnStrongest</option>
+                <option value="dualReturn">dualReturn</option>
+                <option value="tripleReturn">tripleReturn</option>
+              </select>
+            </label>
+            <label>
+              负载采样率（Hz）
+              <input type="number" name="payloadParam.samplingRate" step="1" min="0" />
+            </label>
+            <label>
+              扫描模式
+              <select name="payloadParam.scanningMode">
+                <option value="">（可选）</option>
+                <option value="repetitive">repetitive</option>
+                <option value="nonRepetitive">nonRepetitive</option>
+              </select>
+            </label>
+            <label>
+              真彩上色
+              <select name="payloadParam.modelColoringEnable">
+                <option value="">（可选）</option>
+                <option value="0">0</option>
+                <option value="1">1</option>
+              </select>
+            </label>
+            <label>
+              图片格式列表（逗号分隔）
+              <input type="text" name="payloadParam.imageFormat" placeholder="例如：wide,zoom" />
+            </label>
+          </div>
+        </div>
+        <div class="actions">
+          <div class="spacer"></div>
+          <button type="submit">保存模板信息</button>
+        </div>
+      </form>
+      <p id="templateStatus" class="status"></p>
+    </section>
+
+    <section class="card layout">
+      <div class="form-panel">
+        <h2>4. 新增航点（<code>&lt;Placemark&gt;</code>）</h2>
+        <form id="waypointForm" class="stack">
+          <input type="hidden" name="editIndex" />
+          <label>
+            航点名称（<code>&lt;name&gt;</code>）
+            <input type="text" name="name" required placeholder="示例：航点 1" />
+          </label>
+          <label>
+            描述（可选）
+            <textarea name="description" rows="2" placeholder="补充说明"></textarea>
+          </label>
+          <div class="field-grid">
+            <label>
+              经度
+              <input type="number" name="longitude" step="any" required />
+            </label>
+            <label>
+              纬度
+              <input type="number" name="latitude" step="any" required />
+            </label>
+            <label>
+              高程（可选，写入 <code>&lt;coordinates&gt;</code>）
+              <input type="number" name="coordinateAltitude" step="any" />
+            </label>
+          </div>
+          <div class="field-grid">
+            <label>
+              椭球高度（m，<code>&lt;wpml:ellipsoidHeight&gt;</code>）
+              <input type="number" name="ellipsoidHeight" step="any" />
+            </label>
+            <label>
+              AGL 高度（m，<code>&lt;wpml:height&gt;</code>）
+              <input type="number" name="height" step="any" />
+            </label>
+            <label>
+              云台俯仰角（°，<code>&lt;wpml:gimbalPitchAngle&gt;</code>）
+              <input type="number" name="gimbalPitchAngle" step="any" />
+            </label>
+          </div>
+          <div class="field-grid">
+            <label class="checkbox">
+              <input type="checkbox" name="useGlobalHeight" checked />
+              <span>继承全局高度</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="useGlobalSpeed" checked />
+              <span>继承全局速度</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="useGlobalHeadingParam" checked />
+              <span>继承全局偏航参数</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="useGlobalTurnParam" checked />
+              <span>继承全局转弯参数</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="useStraightLine" />
+              <span>航段贴合直线</span>
+            </label>
+            <label class="checkbox">
+              <input type="checkbox" name="isRisky" />
+              <span>标记为危险点</span>
+            </label>
+          </div>
+          <div class="subsection">
+            <h3>航点速度（<code>&lt;wpml:waypointSpeed&gt;</code>）</h3>
+            <label>
+              当不继承全局速度时的目标速度（m/s）
+              <input type="number" name="waypointSpeed" step="any" />
+            </label>
+          </div>
+          <div class="subsection">
+            <h3>航点偏航参数（<code>&lt;wpml:waypointHeadingParam&gt;</code>）</h3>
+            <div class="field-grid">
+              <label>
+                偏航模式
+                <select name="waypointHeadingMode">
+                  <option value="followWayline">followWayline</option>
+                  <option value="manually">manually</option>
+                  <option value="fixed">fixed</option>
+                  <option value="smoothTransition">smoothTransition</option>
+                  <option value="towardPOI">towardPOI</option>
+                </select>
+              </label>
+              <label>
+                偏航角（°）
+                <input type="number" name="waypointHeadingAngle" step="any" />
+              </label>
+              <label>
+                兴趣点（lat,lon,height）
+                <input type="text" name="waypointPoiPoint" placeholder="例如：23.98,115.98,0" />
+              </label>
+              <label>
+                偏航转动方向
+                <select name="waypointHeadingPathMode">
+                  <option value="clockwise">clockwise</option>
+                  <option value="counterClockwise">counterClockwise</option>
+                  <option value="followBadArc">followBadArc</option>
+                </select>
+              </label>
+            </div>
+          </div>
+          <div class="subsection">
+            <h3>航点转弯参数（<code>&lt;wpml:waypointTurnParam&gt;</code>）</h3>
+            <div class="field-grid">
+              <label>
+                转弯模式
+                <select name="waypointTurnMode">
+                  <option value="coordinateTurn">coordinateTurn</option>
+                  <option value="toPointAndStopWithDiscontinuityCurvature">toPointAndStopWithDiscontinuityCurvature</option>
+                  <option value="toPointAndStopWithContinuityCurvature">toPointAndStopWithContinuityCurvature</option>
+                  <option value="toPointAndPassWithContinuityCurvature">toPointAndPassWithContinuityCurvature</option>
+                </select>
+              </label>
+              <label>
+                转弯截距（m）
+                <input type="number" name="waypointTurnDampingDist" step="any" />
+              </label>
+            </div>
+          </div>
+          <div class="actions">
+            <button type="submit">保存航点</button>
+            <button type="button" class="secondary" id="waypointReset">清空表单</button>
+          </div>
+        </form>
+      </div>
+      <div class="map-panel">
+        <h2>航点预览</h2>
+        <div id="map"></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>5. 航点列表</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>名称</th>
+              <th>经度</th>
+              <th>纬度</th>
+              <th>AGL 高度</th>
+              <th>继承项</th>
+              <th>标签</th>
+              <th>操作</th>
+            </tr>
+          </thead>
+          <tbody id="waypointTable"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>6. 导出</h2>
+      <p class="hint">
+        下载前请确保创建信息、任务配置、模板参数均已保存，并至少新增一个航点。
+      </p>
+      <div class="actions">
+        <button id="downloadKML" class="secondary">下载 KML</button>
+        <button id="downloadKMZ">下载 KMZ</button>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <small>提示：在列表中点击“编辑”可回填航点表单，按顺序逐项完善模板。</small>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
   </header>
 
   <main>
-    <section class="card">
+    <div class="workspace-grid">
+      <div class="workspace-forms">
+        <section class="card">
       <h2>1. 创建信息</h2>
       <form id="creationForm" class="stack">
         <div class="field-grid">
@@ -44,9 +46,9 @@
         </div>
       </form>
       <p id="creationStatus" class="status"></p>
-    </section>
+        </section>
 
-    <section class="card">
+        <section class="card">
       <h2>2. 任务配置（<code>&lt;wpml:missionConfig&gt;</code>）</h2>
       <form id="missionForm" class="stack">
         <div class="field-grid">
@@ -346,12 +348,12 @@
         </div>
       </form>
       <p id="templateStatus" class="status"></p>
-    </section>
+        </section>
 
-    <section class="card layout">
-      <div class="form-panel">
-        <h2>4. 新增航点（<code>&lt;Placemark&gt;</code>）</h2>
-        <form id="waypointForm" class="stack">
+        <section class="card waypoint-layout">
+          <div class="form-panel">
+            <h2>4. 新增航点（<code>&lt;Placemark&gt;</code>）</h2>
+            <form id="waypointForm" class="stack">
           <input type="hidden" name="editIndex" />
           <label>
             <span class="label-title">航点名称（<code>&lt;name&gt;</code>）</span>
@@ -504,49 +506,62 @@
               </label>
             </div>
           </div>
-          <div class="actions">
-            <button type="submit">保存航点</button>
-            <button type="button" class="secondary" id="waypointReset">清空表单</button>
+              <div class="actions">
+                <button type="submit">保存航点</button>
+                <button type="button" class="secondary" id="waypointReset">清空表单</button>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-      <div class="map-panel">
-        <h2>航点预览</h2>
-        <div id="map"></div>
-      </div>
-    </section>
+          <div class="map-panel">
+            <h2>航点预览</h2>
+            <div id="map"></div>
+          </div>
+        </section>
 
-    <section class="card">
-      <h2>5. 航点列表</h2>
-      <div class="table-wrapper">
-        <table>
-          <thead>
-            <tr>
-              <th>#</th>
-              <th>名称</th>
-              <th>经度</th>
-              <th>纬度</th>
-              <th>AGL 高度</th>
-              <th>继承项</th>
-              <th>标签</th>
-              <th>操作</th>
-            </tr>
-          </thead>
-          <tbody id="waypointTable"></tbody>
-        </table>
-      </div>
-    </section>
+        <section class="card">
+          <h2>5. 航点列表</h2>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>名称</th>
+                  <th>经度</th>
+                  <th>纬度</th>
+                  <th>AGL 高度</th>
+                  <th>继承项</th>
+                  <th>标签</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody id="waypointTable"></tbody>
+            </table>
+          </div>
+        </section>
 
-    <section class="card">
-      <h2>6. 导出</h2>
-      <p class="hint">
-        下载前请确保创建信息、任务配置、模板参数均已保存，并至少新增一个航点。
-      </p>
-      <div class="actions">
-        <button id="downloadKML" class="secondary">下载 KML</button>
-        <button id="downloadKMZ">下载 KMZ</button>
+        <section class="card">
+          <h2>6. 导出</h2>
+          <p class="hint">
+            下载前请确保创建信息、任务配置、模板参数均已保存，并至少新增一个航点。
+          </p>
+          <div class="actions">
+            <button id="downloadKML" class="secondary">下载 KML</button>
+            <button id="downloadKMZ">下载 KMZ</button>
+          </div>
+        </section>
       </div>
-    </section>
+      <aside class="workspace-preview card">
+        <h2>实时 XML 预览</h2>
+        <div class="preview-group">
+          <h3>template.kml</h3>
+          <pre id="templatePreview" class="code-preview" aria-live="polite">请填写表单以生成 template.kml 预览。</pre>
+        </div>
+        <div class="preview-group">
+          <h3>waylines.wpml</h3>
+          <pre id="waylinesPreview" class="code-preview" aria-live="polite">请填写表单并添加航点以生成 waylines.wpml 预览。</pre>
+        </div>
+      </aside>
+    </div>
   </main>
 
   <footer>

--- a/styles.css
+++ b/styles.css
@@ -59,8 +59,57 @@ header p {
 
 main {
   padding: clamp(1rem, 3vw, 2.5rem);
+}
+
+.workspace-grid {
   display: grid;
   gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.workspace-forms {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.workspace-preview {
+  position: sticky;
+  top: clamp(1rem, 3vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-self: start;
+}
+
+.workspace-preview h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.preview-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.code-preview {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+  font-family: 'Fira Code', 'JetBrains Mono', 'SFMono-Regular', 'Consolas', monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  overflow: auto;
+  max-height: clamp(280px, 50vh, 460px);
+  white-space: pre;
+}
+
+@media (prefers-color-scheme: dark) {
+  .code-preview {
+    background: rgba(148, 163, 184, 0.08);
+  }
 }
 
 .card {
@@ -276,7 +325,7 @@ tr:hover td {
   font-style: italic;
 }
 
-.layout {
+.waypoint-layout {
   display: grid;
   grid-template-columns: minmax(280px, 420px) minmax(280px, 1fr);
   gap: clamp(1rem, 3vw, 2rem);
@@ -302,8 +351,23 @@ footer {
   text-align: center;
 }
 
+@media (min-width: 1100px) {
+  .workspace-grid {
+    grid-template-columns: minmax(0, 1.75fr) minmax(320px, 1fr);
+    align-items: start;
+  }
+}
+
 @media (max-width: 960px) {
-  .layout {
+  .workspace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-preview {
+    position: static;
+  }
+
+  .waypoint-layout {
     grid-template-columns: 1fr;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -114,14 +114,31 @@ label {
   flex-direction: column;
   gap: 0.35rem;
   font-weight: 600;
+  color: var(--text);
+}
+
+label .label-title {
+  font-weight: inherit;
+}
+
+label .field-hint {
+  font-weight: 400;
+  font-size: 0.85rem;
   color: var(--text-light);
+  line-height: 1.4;
 }
 
 label.checkbox {
-  flex-direction: row;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.checkbox-main {
+  display: flex;
   align-items: center;
   gap: 0.6rem;
-  font-weight: 500;
 }
 
 input,

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,296 @@
+:root {
+  color-scheme: light dark;
+  --background: #f6f7fb;
+  --card-bg: #ffffff;
+  --border: rgba(0, 0, 0, 0.08);
+  --text: #1f2933;
+  --text-light: #6c7280;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --accent-contrast: #ffffff;
+  --muted-bg: rgba(37, 99, 235, 0.08);
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'PingFang SC', sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0f172a;
+    --card-bg: #15203b;
+    --border: rgba(255, 255, 255, 0.1);
+    --text: #e2e8f0;
+    --text-light: #94a3b8;
+    --accent: #3b82f6;
+    --accent-dark: #2563eb;
+    --muted-bg: rgba(59, 130, 246, 0.16);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+header,
+footer {
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem);
+}
+
+header {
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+}
+
+header p {
+  margin: 0;
+  color: var(--text-light);
+  max-width: 720px;
+}
+
+main {
+  padding: clamp(1rem, 3vw, 2.5rem);
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: clamp(1.25rem, 2vw, 1.75rem);
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.subsection {
+  padding: 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.subsection h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+label.field-disabled {
+  opacity: 0.6;
+}
+
+.field-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+label.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 500;
+}
+
+input,
+select,
+textarea {
+  font: inherit;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.55rem 0.75rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 90px;
+}
+
+@media (prefers-color-scheme: dark) {
+  input,
+  select,
+  textarea {
+    background: rgba(15, 23, 42, 0.8);
+  }
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--muted-bg);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.actions .spacer {
+  flex: 1;
+}
+
+button {
+  font: inherit;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-weight: 600;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+}
+
+button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+button.secondary {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+}
+
+button.secondary:hover {
+  background: rgba(37, 99, 235, 0.22);
+}
+
+button.disabled,
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+  transform: none;
+}
+
+.status {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--accent);
+  min-height: 1.2rem;
+}
+
+.hint {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: var(--text-light);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+thead {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+thead th {
+  text-align: left;
+  padding: 0.75rem;
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+tbody td {
+  padding: 0.75rem;
+  border-top: 1px solid var(--border);
+}
+
+tr:nth-child(even) td {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+tr:hover td {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.empty-row td {
+  text-align: center;
+  color: var(--text-light);
+  font-style: italic;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 420px) minmax(280px, 1fr);
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: start;
+}
+
+.map-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#map {
+  width: 100%;
+  min-height: 320px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+footer {
+  color: var(--text-light);
+  text-align: center;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  table {
+    min-width: unset;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -132,6 +132,22 @@ main {
   gap: 1rem;
 }
 
+.file-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  background: var(--muted-bg);
+  color: var(--text);
+}
+
+.file-input input[type='file'] {
+  font-size: 0.95rem;
+  color: inherit;
+}
+
 .subsection {
   padding: 1rem;
   border: 1px dashed var(--border);


### PR DESCRIPTION
## Summary
- capture mission globalRTHHeight, template globalHeight, and align template type options
- add payloadParam editing/export and waypoint-level speed/heading/turn controls with flags
- extend the UI with subsection styling, badges, and field disabling for inheritance toggles

## Testing
- Not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68db9331691c832da7579ad0f5985307